### PR TITLE
[IMP]12573: make custom color for fsm stage will reflect to geoengine mapping

### DIFF
--- a/fieldservice/data/fsm_stage.xml
+++ b/fieldservice/data/fsm_stage.xml
@@ -11,8 +11,8 @@
         <field name="sequence">20</field>
     </record>
 
-    <record id="fsm_stage_scheduled" model="fsm.stage">
-        <field name="name">Scheduled</field>
+    <record id="fsm_stage_requested" model="fsm.stage">
+        <field name="name">Requested</field>
         <field name="sequence">30</field>
     </record>
 
@@ -21,8 +21,8 @@
         <field name="sequence">40</field>
     </record>
 
-    <record id="fsm_stage_planned" model="fsm.stage">
-        <field name="name">Planned</field>
+    <record id="fsm_stage_scheduled" model="fsm.stage">
+        <field name="name">Scheduled</field>
         <field name="sequence">50</field>
     </record>
 

--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -17,6 +17,11 @@ class FSMOrder(geo_model.GeoModel):
     def _default_stage_id(self):
         return self.env.ref('fieldservice.fsm_stage_new')
 
+    @api.depends('stage_id')
+    def _get_stage_color(self):
+        """ Get stage color"""
+        self.custom_color = self.stage_id.custom_color or '#FFFFFF'
+
     stage_id = fields.Many2one('fsm.stage', string='Stage',
                                track_visibility='onchange',
                                index=True,
@@ -89,6 +94,9 @@ class FSMOrder(geo_model.GeoModel):
     mobile = fields.Char(related="location_id.mobile")
 
     stage_name = fields.Char(related="stage_id.name", string="Stage")
+    # Field for Stage Color
+    custom_color = fields.Char(related="stage_id.custom_color",
+                               string='Stage Color')
 
     # Template
     template_id = fields.Many2one('fsm.template', string="Template")
@@ -110,17 +118,17 @@ class FSMOrder(geo_model.GeoModel):
     def write(self, vals):
         if 'scheduled_date_end' in vals:
             date_to_with_delta = fields.Datetime.from_string(
-                vals.get('scheduled_date_end')) -\
+                vals.get('scheduled_date_end')) - \
                 timedelta(hours=self.scheduled_duration)
             vals['scheduled_date_start'] = str(date_to_with_delta)
         if 'scheduled_duration' in vals:
             date_to_with_delta = fields.Datetime.from_string(
-                vals.get('scheduled_date_start', self.scheduled_date_start)) +\
+                vals.get('scheduled_date_start', self.scheduled_date_start)) + \
                 timedelta(hours=vals.get('scheduled_duration'))
             vals['scheduled_date_end'] = str(date_to_with_delta)
         if 'scheduled_date_end' not in vals and 'scheduled_date_start' in vals:
             date_to_with_delta = fields.Datetime.from_string(
-                vals.get('scheduled_date_start')) +\
+                vals.get('scheduled_date_start')) + \
                 timedelta(hours=self.scheduled_duration)
             vals['scheduled_date_end'] = str(date_to_with_delta)
         return super(FSMOrder, self).write(vals)
@@ -186,7 +194,7 @@ class FSMOrder(geo_model.GeoModel):
     def onchange_scheduled_date_end(self):
         if self.scheduled_date_end:
             date_to_with_delta = fields.Datetime.from_string(
-                self.scheduled_date_end) -\
+                self.scheduled_date_end) - \
                 timedelta(hours=self.scheduled_duration)
             self.date_start = str(date_to_with_delta)
 
@@ -194,7 +202,7 @@ class FSMOrder(geo_model.GeoModel):
     def onchange_scheduled_duration(self):
         if self.scheduled_duration:
             date_to_with_delta = fields.Datetime.from_string(
-                self.scheduled_date_start) +\
+                self.scheduled_date_start) + \
                 timedelta(hours=self.scheduled_duration)
             self.scheduled_date_end = str(date_to_with_delta)
 

--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -123,8 +123,8 @@ class FSMOrder(geo_model.GeoModel):
             vals['scheduled_date_start'] = str(date_to_with_delta)
         if 'scheduled_duration' in vals:
             date_to_with_delta = fields.Datetime.from_string(
-                vals.get('scheduled_date_start', self.scheduled_date_start)) + \
-                timedelta(hours=vals.get('scheduled_duration'))
+                vals.get('scheduled_date_start', self.scheduled_date_start))\
+                + timedelta(hours=vals.get('scheduled_duration'))
             vals['scheduled_date_end'] = str(date_to_with_delta)
         if 'scheduled_date_end' not in vals and 'scheduled_date_start' in vals:
             date_to_with_delta = fields.Datetime.from_string(
@@ -137,17 +137,17 @@ class FSMOrder(geo_model.GeoModel):
         return self.write({'stage_id': self.env.ref(
             'fieldservice.fsm_stage_confirmed').id})
 
-    def action_schedule(self):
+    def action_request(self):
         return self.write({'stage_id': self.env.ref(
-            'fieldservice.fsm_stage_scheduled').id})
+            'fieldservice.fsm_stage_requested').id})
 
     def action_assign(self):
         return self.write({'stage_id': self.env.ref(
             'fieldservice.fsm_stage_assigned').id})
 
-    def action_plan(self):
+    def action_schedule(self):
         return self.write({'stage_id': self.env.ref(
-            'fieldservice.fsm_stage_planned').id})
+            'fieldservice.fsm_stage_scheduled').id})
 
     def action_enroute(self):
         return self.write({'stage_id': self.env.ref(
@@ -168,25 +168,18 @@ class FSMOrder(geo_model.GeoModel):
     @api.onchange('scheduled_date_start')
     def onchange_scheduled_date_start(self):
         if self.person_id and self.scheduled_date_start:
-            print(self.person_id)
-            print(self.person_id)
-            print("person")
             # self.stage_id = 'Planned'
             self.stage_id = 5
         elif not self.person_id and self.scheduled_date_start:
-            print("hello")
             # self.stage_id = 'Scheduled'
             self.stage_id = 3
 
     @api.onchange('person_id')
     def onchange_person_id(self):
         if self.person_id and self.scheduled_date_start:
-            print(self.scheduled_date_start)
-            print("date")
             # self.stage_id = 'Planned'
             self.stage_id = 5
         elif self.person_id and not self.scheduled_date_start:
-            print("hello")
             # self.stage_id = 'Assigned'
             self.stage_id = 4
 

--- a/fieldservice/models/fsm_stage.py
+++ b/fieldservice/models/fsm_stage.py
@@ -1,8 +1,7 @@
 # Copyright (C) 2018 - TODAY, Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
-
+from odoo import api, fields, models
 
 AVAILABLE_PRIORITIES = [
     ('0', 'Normal'),
@@ -32,3 +31,19 @@ class FSMStage(models.Model):
     is_closed = fields.Boolean('Is a close stage',
                                help='Services in this stage are considered '
                                     'as closed.')
+    custom_color = fields.Char("Color Code", default="#FFFFFF")
+
+    @api.multi
+    def get_color_information(self):
+        # get stage ids
+        stage_ids = self.search([])
+        color_information_dict = []
+        for stage in stage_ids:
+            color_information_dict.append({
+                'color': stage.custom_color,
+                'field': 'stage_id',
+                'opt': '==',
+                'value': stage.name,
+            })
+        return color_information_dict
+

--- a/fieldservice/models/fsm_stage.py
+++ b/fieldservice/models/fsm_stage.py
@@ -46,4 +46,3 @@ class FSMStage(models.Model):
                 'value': stage.name,
             })
         return color_information_dict
-

--- a/fieldservice/readme/CONFIGURE.rst
+++ b/fieldservice/readme/CONFIGURE.rst
@@ -10,3 +10,4 @@ You need to add attribute mention below with the tag <timeline> as base element.
   example custom_color = "true". And there is minor condition to follow to
   implement this as. Define any one stage color condition like 
   colors="#ffffff:stage_id=='New';"
+

--- a/fieldservice/readme/CONFIGURE.rst
+++ b/fieldservice/readme/CONFIGURE.rst
@@ -1,3 +1,12 @@
 To configure this module, you need to:
 
 * Go to Field Service > Configuration > Settings
+
+You need to add attribute mention below with the tag <timeline> as base element.
+
+* colors (optional): it allows to set certain specific colors if the expressed
+  condition (JS syntax) is met.
+* custom_color (optional): it allows to set custom color for fsm.stages
+  example custom_color = "true". And there is minor condition to follow to
+  implement this as. Define any one stage color condition like 
+  colors="#ffffff:stage_id=='New';"

--- a/fieldservice/static/src/js/fsm_gantt.js
+++ b/fieldservice/static/src/js/fsm_gantt.js
@@ -46,6 +46,16 @@ odoo.define('fieldservice.fsm_gantt', function (require) {
                     self.res_users_ids.push(result[r].id);
                 }
             });
+            // Find custom color if mentioned
+            if (params.arch.attrs.custom_color === "true") {
+                this._rpc({
+                    model: 'fsm.stage',
+                    method: 'get_color_information',
+                    args: [[], {}],
+                }).then(function (result) {
+                    self.colors = result
+                });
+            }
         },
 
         /**

--- a/fieldservice/static/src/js/fsm_gantt.js
+++ b/fieldservice/static/src/js/fsm_gantt.js
@@ -53,7 +53,7 @@ odoo.define('fieldservice.fsm_gantt', function (require) {
                     method: 'get_color_information',
                     args: [[], {}],
                 }).then(function (result) {
-                    self.colors = result
+                    self.colors = result;
                 });
             }
         },

--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -13,8 +13,8 @@
                             class="oe_highlight"
                             type="object" groups="fieldservice.group_fsm_dispatcher"
                             attrs="{'invisible': [('stage_id', '!=', %(fieldservice.fsm_stage_new)d)]}"/>
-                    <button id="action_schedule"
-                            name="action_schedule" string="Schedule"
+                    <button id="action_request"
+                            name="action_request" string="Request"
                             class="oe_highlight"
                             type="object" groups="fieldservice.group_fsm_dispatcher"
                             attrs="{'invisible': [('stage_id', '!=', %(fieldservice.fsm_stage_confirmed)d)]}"/>
@@ -22,9 +22,9 @@
                             name="action_assign" string="Assign"
                             class="oe_highlight"
                             type="object" groups="fieldservice.group_fsm_dispatcher"
-                            attrs="{'invisible': [('stage_id', '!=', %(fieldservice.fsm_stage_scheduled)d)]}"/>
-                    <button id="action_plan"
-                            name="action_plan" string="Plan"
+                            attrs="{'invisible': [('stage_id', '!=', %(fieldservice.fsm_stage_requested)d)]}"/>
+                    <button id="action_schedule"
+                            name="action_schedule" string="Schedule"
                             class="oe_highlight"
                             type="object" groups="fieldservice.group_fsm_dispatcher"
                             attrs="{'invisible': [('stage_id', '!=', %(fieldservice.fsm_stage_assigned)d)]}"/>
@@ -32,7 +32,7 @@
                             name="action_enroute" string="En Route"
                             class="oe_highlight"
                             type="object" groups="fieldservice.group_fsm_dispatcher"
-                            attrs="{'invisible': [('stage_id', '!=', %(fieldservice.fsm_stage_planned)d)]}"/>
+                            attrs="{'invisible': [('stage_id', '!=', %(fieldservice.fsm_stage_scheduled)d)]}"/>
                     <button id="action_start"
                             name="action_start" string="Start"
                             class="oe_highlight"

--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -281,7 +281,8 @@
                       string="Orders"
                       default_group_by="person_id"
                       event_open_popup="true"
-                      colors="#ffffff:stage_id=='New'#ffffff:stage_id=='Confirmed';#00ff00:stage_id=='Scheduled';#add8e6:stage_id=='Assigned';#ff00ff:stage_id=='Planned';#9370DB:stage_id=='En Route';#4B0082:stage_id=='Started';#808080:stage_id=='Completed';#D3D3D3:stage_id=='Cancelled';">
+                      colors="#ffffff:stage_id=='New';"
+                      custom_color="true">
             </timeline>
         </field>
     </record>
@@ -348,7 +349,8 @@
                 <field name='zip'/>
                 <field name="country_name"/>
                 <field name='stage_name'/>
-                <field name="shape"/>  
+                <field name="shape"/>
+                <field name="custom_color"/>
             </geoengine>
         </field>
         <field eval="16" name="priority"/>
@@ -368,7 +370,19 @@
         <field name="attribute_field_id" ref="fieldservice.field_fsm_order_stage_name"/>
         <field name="begin_color">#0AFF68</field>
     </record>
-    
+
+    <record id="geoengine_vector_layer_fsmordertatecoloredcustom0" model="geoengine.vector.layer">
+      <field name="geo_field_id" ref="fieldservice.field_fsm_order_shape"/>
+      <field name="name">FSM Order State colored custom</field>
+      <field name="classification">custom</field>
+      <field eval="6" name="sequence"/>
+      <field name="view_id" ref="ir_ui_view_fsm_order_map"/>
+      <field name="geo_repr">colored</field>
+      <field eval="1" name="nb_class"/>
+      <field name="attribute_field_id" ref="fieldservice.field_fsm_order_custom_color"/>
+      <field name="begin_color">#FFFFFF</field>
+    </record>
+
     <record id="geoengine_raster_layer_retailmachineosm" model="geoengine.raster.layer">
         <field name="raster_type">osm</field>
         <field name="name">Open Street Map</field>

--- a/fieldservice/views/fsm_stage.xml
+++ b/fieldservice/views/fsm_stage.xml
@@ -9,6 +9,7 @@
             <tree string="Stages">
                 <field name="name"/>
                 <field name="is_closed"/>
+                <field name="custom_color"/>
             </tree>
         </field>
     </record>
@@ -25,6 +26,7 @@
                             <field name="sequence"/>
                         </group>
                         <group>
+                            <field name="custom_color"/>
                             <field name="fold"/>
                             <field name="is_closed"/>
                         </group>


### PR DESCRIPTION
Modified module:
> fieldservice

Included features:
1. Custom color support for geoengine mapping
2. Increase marker/pointer size in base_geoengine mapping
3. Custom color support for gantt/web_timeline view with fsm.stage color

Note: This change will only work once we include PR https://github.com/asaunier/geospatial/pull/1 with base_geoengine repo.