### PR TITLE
[FIX] FSM Gantt chart fixes

### DIFF
--- a/fieldservice/static/src/js/fsm_gantt.js
+++ b/fieldservice/static/src/js/fsm_gantt.js
@@ -66,7 +66,19 @@ odoo.define('fieldservice.fsm_gantt', function (require) {
          * @param {Object} adjust_window
          */
         on_data_loaded_2 : function (events, group_bys, adjust_window) {
+        	console.log('on_data_loaded_2');
             var self = this;
+            // Make the user filter clear
+            self.$el.find(
+                '#user_filer .o_searchview_extended_prop_field').val('');
+            self.$el.find(
+                '#user_filer .o_searchview_extended_prop_field').change();
+            self.$el.find(
+                '#user_filer .o_searchview_extended_prop_field').val(
+                'category_id');
+            self.$el.find(
+                '#user_filer .o_searchview_extended_prop_field').change();
+            // Make the user filter clear
             var data = [];
             var groups = [];
             this.grouped_by = group_bys;
@@ -112,6 +124,9 @@ odoo.define('fieldservice.fsm_gantt', function (require) {
             this.timeline.setItems(data);
             var mode = !this.mode || this.mode === 'fit';
             var adjust = _.isUndefined(adjust_window) || adjust_window;
+            this.timeline.setOptions({
+                orientation: 'top',
+            });
             if (mode && adjust) {
                 this.timeline.fit();
             }

--- a/fieldservice/static/src/js/fsm_gantt.js
+++ b/fieldservice/static/src/js/fsm_gantt.js
@@ -66,7 +66,6 @@ odoo.define('fieldservice.fsm_gantt', function (require) {
          * @param {Object} adjust_window
          */
         on_data_loaded_2 : function (events, group_bys, adjust_window) {
-        	console.log('on_data_loaded_2');
             var self = this;
             // Make the user filter clear
             self.$el.find(

--- a/fieldservice/views/fsm_team.xml
+++ b/fieldservice/views/fsm_team.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <template id="assets_backend" name="fsm_team_assets" inherit_id="web.assets_backend">
+    <template id="assets_backend_team" name="fsm_team_assets" inherit_id="web.assets_backend">
             <xpath expr="." position="inside">
                 <link rel="stylesheet" href="/fieldservice/static/src/less/team_dashboard.less"/>
             </xpath>


### PR DESCRIPTION
1. Make gantt chart visibility on top always  (it will avoid focus on bottom every time)
2. On gantt view load, clear the person filter (it will automatically clear filter)
3. give fsm team css with unique template id to avoid conflicts with gantt chart functionalities (it will resolve the issue of FSM team feature conflicts)

@max3903  : Can you please merge this? Thanks

CC: @wolfhall 
@osi-scampbell : Point 3 is the fix for FSM Team, in future please use template ID unique every time you define for custom purpose. Thanks