### PR TITLE
[FIX] fieldservice_recurring

### DIFF
--- a/fieldservice_recurring/models/fsm_frequency.py
+++ b/fieldservice_recurring/models/fsm_frequency.py
@@ -26,6 +26,13 @@ FREQUENCIES = {
     'daily': DAILY,
 }
 
+FREQUENCY_SELECT = [
+    ('yearly', 'Yearly'),
+    ('monthly', 'Monthly'),
+    ('weekly', 'Weekly'),
+    ('daily', 'Daily')
+]
+
 
 class FSMFrequency(models.Model):
     _name = 'fsm.frequency'
@@ -38,7 +45,7 @@ class FSMFrequency(models.Model):
         string='Repeat Every', help="The number of intervals between events",
         default=1, required=True, track_visibility='onchange')
     interval_type = fields.Selection(
-        FREQUENCIES, string='Interval Type',
+        FREQUENCY_SELECT, string='Interval Type',
         required=True, track_visibility='onchange')
     is_exclusive = fields.Boolean(
         string='Exclusive Rule?', default=False,


### PR DESCRIPTION
_Originally posted by @max3903 in https://github.com/_render_node/MDIzOlB1bGxSZXF1ZXN0UmV2aWV3VGhyZWFkMTcxOTE2Njc3OnYy/pull_request_review_threads/discussion_

>```suggestion
>    interval_type = fields.Selection(FREQUENCIES,
>```
>
>Can you use the variable defined above?
>Like here:
>https://github.com/OCA/field-service/blob/12.0/fieldservice_stock/models/fsm_order.py#L43


The variable FREQUENCIES was a dictionary used for technical purposes for the recurring rules.  We need a tuple type to use as a variable for the selection field (which is same options as the other variable)  
