### PR TITLE
[FIX] fieldservice_partner_multi_relation: Smart Button FSM Location to Relations

### DIFF
--- a/fieldservice_partner_multi_relation/__manifest__.py
+++ b/fieldservice_partner_multi_relation/__manifest__.py
@@ -12,6 +12,10 @@
         'partner_multi_relation',
         'fieldservice'
     ],
+    "data": [
+        'views/fsm_location.xml',
+        'views/menu.xml'
+    ],
     "demo": [
         "data/demo.xml",
     ],

--- a/fieldservice_partner_multi_relation/models/__init__.py
+++ b/fieldservice_partner_multi_relation/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import res_partner_relation_type
 from . import res_partner
+from . import fsm_location

--- a/fieldservice_partner_multi_relation/models/fsm_location.py
+++ b/fieldservice_partner_multi_relation/models/fsm_location.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2018 - TODAY, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class FSMLocation(models.Model):
+    _inherit = 'fsm.location'
+
+    rel_count = fields.Integer(string='Relations',
+                               compute='_compute_relation_count')
+
+    @api.multi
+    def _compute_relation_count(self):
+        for location in self:
+            location.rel_count = self.env['res.partner.relation.all'].\
+                search_count([('this_partner_id', '=', location.name)])
+
+    @api.multi
+    def action_view_relations(self):
+        """
+        This function returns an action that display existing
+        partner relations of a given fsm location id.
+        """
+        for location in self:
+            action = self.env.\
+                ref('partner_multi_relation.tree_res_partner_relation_all').\
+                read()[0]
+            relations = self.env['res.partner.relation.all'].\
+                search([('this_partner_id', '=', location.name)])
+            action = self.env.\
+                ref('partner_multi_relation.action_res_partner_relation_all')\
+                .read()[0]
+            action['domain'] = [('id', 'in', relations.ids)]
+            return action

--- a/fieldservice_partner_multi_relation/views/fsm_location.xml
+++ b/fieldservice_partner_multi_relation/views/fsm_location.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Field Service Location Form View-->
+    <record id="fsm_location_relations_form_view" model="ir.ui.view">
+        <field name="name">fsm.location.relations.form.view</field>
+        <field name="model">fsm.location</field>
+        <field name="inherit_id" ref="fieldservice.fsm_location_form_view"/>
+        <field name="arch" type="xml">
+            <div class="oe_button_box" position="inside">
+                <button name="action_view_relations"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-thumbs-up">
+                    <field name="rel_count"
+                           widget="statinfo"
+                           string="Relations"/>
+                </button>
+            </div>
+        </field>
+    </record>
+</odoo>

--- a/fieldservice_partner_multi_relation/views/menu.xml
+++ b/fieldservice_partner_multi_relation/views/menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <menuitem id="reporting"
+                name="Relations"
+                sequence="40"
+                parent="fieldservice.config"
+                action="partner_multi_relation.action_res_partner_relation_all"
+                groups="fieldservice.group_fsm_dispatcher"/>
+</odoo>


### PR DESCRIPTION
This PR adds a smart button to FSM Locations that displays all of the relations this FMS Location has. This PR also adds a menu item to Field Service under Configuration that links to All Relations