### PR TITLE
[WIP][FIX] fieldservice: perf issue on location

### DIFF
--- a/fieldservice/models/fsm_location.py
+++ b/fieldservice/models/fsm_location.py
@@ -69,7 +69,7 @@ class FSMLocation(models.Model):
     @api.multi
     def _compute_children(self):
         for location in self:
-            children = [self.id]
+            children = [location.id]
 
             def comp_children(self, child_ids):
                 for child_id in child_ids:
@@ -83,7 +83,7 @@ class FSMLocation(models.Model):
             child_ids = self.env['fsm.location'].\
                 search([('fsm_parent_id', '=', location.id)])
             comp_children(self, child_ids)
-            self.child_ids = children
+            location.child_ids = children
 
     @api.multi
     def _compute_equipment_ids(self):

--- a/fieldservice/models/fsm_location.py
+++ b/fieldservice/models/fsm_location.py
@@ -87,8 +87,9 @@ class FSMLocation(models.Model):
 
     @api.multi
     def _compute_equipment_ids(self):
-        self.equipment_count = self.env['fsm.equipment'].\
-            search_count([('location_id', 'in', self.child_ids.ids)])
+        for loc in self:
+            self.equipment_count = self.env['fsm.equipment'].\
+                search_count([('location_id', 'in', loc.child_ids.ids)])
 
     @api.multi
     def action_view_equipment(self):
@@ -116,7 +117,8 @@ class FSMLocation(models.Model):
 
     @api.multi
     def _compute_sublocation_ids(self):
-        self.sublocation_count = (len(self.child_ids.ids) - 1)
+        for loc in self:
+            self.sublocation_count = (len(loc.child_ids.ids) - 1)
 
     @api.multi
     def action_view_sublocation(self):
@@ -143,8 +145,10 @@ class FSMLocation(models.Model):
 
     @api.multi
     def _compute_contact_ids(self):
-        self.contact_count = self.env['res.partner'].\
-            search_count([('service_location_id', 'in', self.child_ids.ids)])
+        for loc in self:
+            self.contact_count = self.env['res.partner'].\
+                search_count([('service_location_id', 'in',
+                loc.child_ids.ids)])
 
     @api.multi
     def action_view_contacts(self):

--- a/fieldservice/models/fsm_location.py
+++ b/fieldservice/models/fsm_location.py
@@ -88,7 +88,7 @@ class FSMLocation(models.Model):
     @api.multi
     def _compute_equipment_ids(self):
         for loc in self:
-            self.equipment_count = self.env['fsm.equipment'].\
+            loc.equipment_count = self.env['fsm.equipment'].\
                 search_count([('location_id', 'in', loc.child_ids.ids)])
 
     @api.multi
@@ -118,7 +118,7 @@ class FSMLocation(models.Model):
     @api.multi
     def _compute_sublocation_ids(self):
         for loc in self:
-            self.sublocation_count = (len(loc.child_ids.ids) - 1)
+            loc.sublocation_count = (len(loc.child_ids.ids) - 1)
 
     @api.multi
     def action_view_sublocation(self):
@@ -146,7 +146,7 @@ class FSMLocation(models.Model):
     @api.multi
     def _compute_contact_ids(self):
         for loc in self:
-            self.contact_count = self.env['res.partner'].\
+            loc.contact_count = self.env['res.partner'].\
                 search_count([('service_location_id', 'in',
                 loc.child_ids.ids)])
 


### PR DESCRIPTION
Users with large amounts of data were noticing slower load times on records that had a lot of sublocations, contacts, and equipment. I believe this issue is because of how the computed fields for the smart buttons were being calculated. The previous code traverses the hierarchy every single time it goes to set the smart button fields (6 times total one for each smart button field).

This PR alters the way the fields are calculated by recursively traversing the hierarchy and saving that locations children in child_ids. Instead of going through every record multiple times building the hierarchy over and over, we only build it once and reference the ids when counting and creating smart button views.