### PR TITLE
[IMP] fieldservice_partner_multi_relation: Integrate FSM in Partner Multi Relation

### DIFF
--- a/fieldservice_partner_multi_relation/data/demo.xml
+++ b/fieldservice_partner_multi_relation/data/demo.xml
@@ -22,19 +22,19 @@
 
     <!-- manages  -->
     <record id="rel_type_manages_loc" model="res.partner.relation.type">
-        <field name="name">[L+L] manges</field>
+        <field name="name">[L+L] manages</field>
         <field name="name_inverse">[L+L] is managed by</field>
         <field name="contact_type_left">fsm-location</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
     <record id="rel_type_manages_org" model="res.partner.relation.type">
-        <field name="name">[C+L] manges</field>
+        <field name="name">[C+L] manages</field>
         <field name="name_inverse">[L+C] is managed by</field>
         <field name="contact_type_left">c</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
     <record id="rel_type_manages_per" model="res.partner.relation.type">
-        <field name="name">[P+L] manges</field>
+        <field name="name">[P+L] manages</field>
         <field name="name_inverse">[L+P] is managed by</field>
         <field name="contact_type_left">p</field>
         <field name="contact_type_right">fsm-location</field>

--- a/fieldservice_partner_multi_relation/data/demo.xml
+++ b/fieldservice_partner_multi_relation/data/demo.xml
@@ -2,140 +2,140 @@
 <odoo>
     <!-- owns  -->
     <record id="rel_type_owns_loc" model="res.partner.relation.type">
-        <field name="name">owns</field>
-        <field name="name_inverse">is owned by</field>
+        <field name="name">[L+L] owns</field>
+        <field name="name_inverse">[L+L] is owned by</field>
         <field name="contact_type_left">fsm-location</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
     <record id="rel_type_owns_per" model="res.partner.relation.type">
-        <field name="name">owns</field>
-        <field name="name_inverse">is owned by</field>
+        <field name="name">[P+L] owns</field>
+        <field name="name_inverse">[L+P] is owned by</field>
         <field name="contact_type_left">p</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
     <record id="rel_type_owns_org" model="res.partner.relation.type">
-        <field name="name">owns</field>
-        <field name="name_inverse">is owned by</field>
+        <field name="name">[C+L] owns</field>
+        <field name="name_inverse">[L+C] is owned by</field>
         <field name="contact_type_left">c</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
 
     <!-- manages  -->
     <record id="rel_type_manages_loc" model="res.partner.relation.type">
-        <field name="name">manges</field>
-        <field name="name_inverse">is managed by</field>
+        <field name="name">[L+L] manges</field>
+        <field name="name_inverse">[L+L] is managed by</field>
         <field name="contact_type_left">fsm-location</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
     <record id="rel_type_manages_org" model="res.partner.relation.type">
-        <field name="name">manges</field>
-        <field name="name_inverse">is managed by</field>
+        <field name="name">[C+L] manges</field>
+        <field name="name_inverse">[L+C] is managed by</field>
         <field name="contact_type_left">c</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
     <record id="rel_type_manages_per" model="res.partner.relation.type">
-        <field name="name">manges</field>
-        <field name="name_inverse">is managed by</field>
+        <field name="name">[P+L] manges</field>
+        <field name="name_inverse">[L+P] is managed by</field>
         <field name="contact_type_left">p</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
 
     <!-- pays the invoices for  -->
     <record id="rel_type_pays_invoices_loc" model="res.partner.relation.type">
-        <field name="name">pays the invoices for</field>
-        <field name="name_inverse">gets the invoices paid by</field>
+        <field name="name">[L+L] pays the invoices for</field>
+        <field name="name_inverse">[L+L] gets the invoices paid by</field>
         <field name="contact_type_left">fsm-location</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
     <record id="rel_type_pays_invoices_org" model="res.partner.relation.type">
-        <field name="name">pays the invoices for</field>
-        <field name="name_inverse">gets the invoices paid by</field>
+        <field name="name">[C+L] pays the invoices for</field>
+        <field name="name_inverse">[L+C] gets the invoices paid by</field>
         <field name="contact_type_left">c</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
     <record id="rel_type_pays_invoices_per" model="res.partner.relation.type">
-        <field name="name">pays the invoices for</field>
-        <field name="name_inverse">gets the invoices paid by</field>
+        <field name="name">[P+L] pays the invoices for</field>
+        <field name="name_inverse">[L+P] gets the invoices paid by</field>
         <field name="contact_type_left">p</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
 
     <!-- is the primary contact of  -->
     <record id="rel_type_primary_contact_loc" model="res.partner.relation.type">
-        <field name="name">is the primary contact of</field>
-        <field name="name_inverse">whose primary contact</field>
+        <field name="name">[L+L] is the primary contact of</field>
+        <field name="name_inverse">[L+L] whose primary contact</field>
         <field name="contact_type_left">fsm-location</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
     <record id="rel_type_primary_contact_org" model="res.partner.relation.type">
-        <field name="name">is the primary contact of</field>
-        <field name="name_inverse">whose primary contact</field>
+        <field name="name">[C+L] is the primary contact of</field>
+        <field name="name_inverse">[L+C] whose primary contact</field>
         <field name="contact_type_left">c</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
     <record id="rel_type_primary_contact_per" model="res.partner.relation.type">
-        <field name="name">is the primary contact of</field>
-        <field name="name_inverse">whose primary contact</field>
+        <field name="name">[P+L] is the primary contact of</field>
+        <field name="name_inverse">[L+P] whose primary contact</field>
         <field name="contact_type_left">p</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
 
     <!-- is the secondary contact of  -->
     <record id="rel_type_secondary_contact_loc" model="res.partner.relation.type">
-        <field name="name">is the secondary contact of</field>
-        <field name="name_inverse">whose secondary contact</field>
+        <field name="name">[L+L] is the secondary contact of</field>
+        <field name="name_inverse">[L+L] whose secondary contact</field>
         <field name="contact_type_left">fsm-location</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
     <record id="rel_type_secondary_contact_org" model="res.partner.relation.type">
-        <field name="name">is the secondary contact of</field>
-        <field name="name_inverse">whose secondary contact</field>
+        <field name="name">[C+L] is the secondary contact of</field>
+        <field name="name_inverse">[L+C] whose secondary contact</field>
         <field name="contact_type_left">c</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
     <record id="rel_type_secondary_contact_per" model="res.partner.relation.type">
-        <field name="name">is the secondary contact of</field>
-        <field name="name_inverse">whose secondary contact</field>
+        <field name="name">[P+L] is the secondary contact of</field>
+        <field name="name_inverse">[L+P] whose secondary contact</field>
         <field name="contact_type_left">p</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
 
     <!-- is a tenant of  -->
     <record id="rel_type_tenant_loc" model="res.partner.relation.type">
-        <field name="name">is a tenant of</field>
-        <field name="name_inverse">is occupied by</field>
+        <field name="name">[L+L] is a tenant of</field>
+        <field name="name_inverse">[L+L] is occupied by</field>
         <field name="contact_type_left">fsm-location</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
     <record id="rel_type_tenant_org" model="res.partner.relation.type">
-        <field name="name">is a tenant of</field>
-        <field name="name_inverse">is occupied by</field>
+        <field name="name">[C+L] is a tenant of</field>
+        <field name="name_inverse">[L+C] is occupied by</field>
         <field name="contact_type_left">c</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
     <record id="rel_type_tenant_per" model="res.partner.relation.type">
-        <field name="name">is a tenant of</field>
-        <field name="name_inverse">is occupied by</field>
+        <field name="name">[P+L] is a tenant of</field>
+        <field name="name_inverse">[L+P] is occupied by</field>
         <field name="contact_type_left">p</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
 
     <!-- is an employee at  -->
     <record id="rel_type_employee_loc" model="res.partner.relation.type">
-        <field name="name">is an employee at</field>
-        <field name="name_inverse">employs</field>
+        <field name="name">[L+L] is an employee at</field>
+        <field name="name_inverse">[L+L] employs</field>
         <field name="contact_type_left">fsm-location</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
     <record id="rel_type_employee_org" model="res.partner.relation.type">
-        <field name="name">is an employee at</field>
-        <field name="name_inverse">employs</field>
+        <field name="name">[C+L] is an employee at</field>
+        <field name="name_inverse">[L+C] employs</field>
         <field name="contact_type_left">c</field>
         <field name="contact_type_right">fsm-location</field>
     </record>
     <record id="rel_type_employee_per" model="res.partner.relation.type">
-        <field name="name">is an employee at</field>
-        <field name="name_inverse">employs</field>
+        <field name="name">[P+L] is an employee at</field>
+        <field name="name_inverse">[L+P] employs</field>
         <field name="contact_type_left">p</field>
         <field name="contact_type_right">fsm-location</field>
     </record>

--- a/fieldservice_partner_multi_relation/models/__init__.py
+++ b/fieldservice_partner_multi_relation/models/__init__.py
@@ -4,4 +4,3 @@ from . import res_partner_relation_type
 from . import res_partner
 from . import fsm_location
 from . import res_partner_relation_all
-

--- a/fieldservice_partner_multi_relation/models/__init__.py
+++ b/fieldservice_partner_multi_relation/models/__init__.py
@@ -3,3 +3,5 @@
 from . import res_partner_relation_type
 from . import res_partner
 from . import fsm_location
+from . import res_partner_relation_all
+

--- a/fieldservice_partner_multi_relation/models/res_partner_relation_all.py
+++ b/fieldservice_partner_multi_relation/models/res_partner_relation_all.py
@@ -1,0 +1,193 @@
+# Copyright (C) 2019 - TODAY, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models, _
+from odoo.exceptions import ValidationError
+
+
+class ResPartnerRelationAll(models.AbstractModel):
+    _inherit = 'res.partner.relation.all'
+
+    @api.onchange('this_partner_id')
+    def onchange_this_partner_id(self):
+        if self.this_partner_id:
+            type_id = self.env['res.partner.relation.type'].search([('name', '=', self.type_selection_id.name)])
+            if (type_id.contact_type_left == 'fsm-location'
+            or type_id.contact_type_right == 'fsm-location'
+            or self.this_partner_id.fsm_location or self.other_partner_id.fsm_location):
+                if not self.type_selection_id:
+                    return self.set_domain_type()
+            elif not self.this_partner_id:
+                if not self.other_partner_id:
+                    return {'domain': {'type_selection_id': ''}}
+                
+            else:
+                super(ResPartnerRelationAll, self).onchange_partner_id()
+        else:
+            # Remove left_cat domain on type
+            return self.set_domain_type()
+
+    @api.onchange('other_partner_id')
+    def onchange_other_partner_id(self):
+        if self.other_partner_id:
+            type_id = self.env['res.partner.relation.type'].search([('name', '=', self.type_selection_id.name)])
+            if (type_id.contact_type_left == 'fsm-location'
+            or type_id.contact_type_right == 'fsm-location'
+            or self.this_partner_id.fsm_location or self.other_partner_id.fsm_location):
+                if not type_id:
+                    return self.set_domain_type()
+                elif not self.other_partner_id:
+                    if not self.this_partner_id:
+                        return {'domain': {'type_selection_id': ''}}
+
+            else:
+                super(ResPartnerRelationAll, self).onchange_partner_id()
+        else:
+            # Remove right_cat domain on type
+            self.set_domain_type()
+
+    @api.onchange('type_selection_id')
+    def onchange_type_selection_id(self):
+        # Clear any prexisting domains
+        if not self.type_selection_id:
+            return {'domain': {'this_partner_id': [('id', '!=', None)], 'other_partner_id': [('id', '!=', None)]}}
+        type_id = self.env['res.partner.relation.type'].search([('name', '=', self.type_selection_id.name)])
+        if (type_id.contact_type_left == 'fsm-location'
+        or type_id.contact_type_right == 'fsm-location'
+        or self.this_partner_id.fsm_location or self.other_partner_id.fsm_location):
+            if self.this_partner_id and self.other_partner_id:
+                # Check
+                self.try_type()
+            elif self.this_partner_id:
+                # Set domain Right
+                res = self.set_domain_right()
+                return res
+            elif self.other_partner_id:
+                # Set domain Left
+                res = self.set_domain_left()
+                return res
+            else:
+                res =  self.set_domain_left()
+                res2 =  self.set_domain_right()
+                res.update(res2['domain'])
+                return res
+        else:
+            super(ResPartnerRelationAll, self).onchange_type_selection_id()
+
+
+    def try_type(self):
+        type_id = self.env['res.partner.relation.type'].search([('name', '=', self.type_selection_id.name)])
+        # From Type
+        left_cat = type_id.contact_type_left
+        right_cat = type_id.contact_type_right
+        # Left Partner
+        left_to_test = self.this_partner_id
+        # Right Partner
+        right_to_test = self.other_partner_id
+
+        # Compare
+        if right_cat == 'p':
+            if left_to_test.company_type != 'person':
+                raise ValidationError(_('Left Partner not type Person'))
+        if right_cat == 'c':
+            if left_to_test.company_type != 'compnay':
+                raise ValidationError(_('Left Partner not type Company'))
+        if right_cat == 'fsm-location':
+            if not left_to_test.fsm_location:
+                raise ValidationError(_('Left Partner not type FSM Location'))
+
+        if right_cat == 'p':
+            if right_to_test.company_type != 'person':
+                raise ValidationError(_('Right Partner not type Person'))
+        if right_cat == 'c':
+            if right_to_test.company_type != 'compnay':
+                raise ValidationError(_('Right Partner not type Company'))
+        if right_cat == 'fsm-location':
+            if not right_to_test.fsm_location:
+                raise ValidationError(_('Right Partner not type FSM Location'))
+
+    def set_domain_left(self):
+        type_id = self.env['res.partner.relation.type'].search([('name', '=', self.type_selection_id.name)])
+        # From Type
+        res = {}
+        # With a Relation Type
+        if type_id:
+            left_cat = type_id.contact_type_left
+            # Create domain for Left based on Type Left Category
+            res = self.build_domain(1, left_cat)
+            return res
+        # Without a Relation Type
+        else:
+            res = {'domain': {'this_partner_id': ''}}
+
+    def set_domain_right(self):
+        type_id = self.env['res.partner.relation.type'].search([('name', '=', self.type_selection_id.name)])
+        # From Type
+        res = {}
+        # With a Relation Type
+        if type_id:
+            right_cat = type_id.contact_type_right
+            # Create domain for Right based on Type Right Category
+            res = self.build_domain(0, right_cat)
+            return res
+        # Wtihout a Relation Type
+        else:
+            res = {'domain': {'other_partner_id': ''}}
+                        
+    def set_domain_type(self):
+        res = {}
+        # If Left & Right then Type must match both
+        if self.this_partner_id and self.other_partner_id:
+            left_cat = self.get_cat(self.this_partner_id)
+            right_cat = self.get_cat(self.other_partner_id)
+            type_ids = self.env['res.partner.relation.type'].\
+                search([('contact_type_left', '=', left_cat), ('contact_type_right', '=', right_cat)])
+            type_names = []
+            for type_id in type_ids:
+                type_names.append(type_id.name)
+            # From Type
+            res = {'domain': {'type_selection_id': [('name', 'in', type_names)]}}
+        # If Left Type must match Left
+        elif self.this_partner_id:
+            left_cat = self.get_cat(self.this_partner_id)
+            type_ids = self.env['res.partner.relation.type'].search([('contact_type_left', '=', left_cat)])
+            type_names = []
+            for type_id in type_ids:
+                type_names.append(type_id.name)
+            res = {'domain': {'type_selection_id': [('name', 'in', type_names)]}}
+        # If Right Type must match Right
+        elif self.other_partner_id:
+            right_cat = self.get_cat(self.other_partner_id)
+            type_ids = self.env['res.partner.relation.type'].search([('contact_type_right', '=', right_cat)])
+            type_names = []
+            for type_id in type_ids:
+                type_names.append(type_id.name)
+            res = {'domain': {'type_selection_id': [('name', 'in', type_names)]}}
+        return res            
+
+    def build_domain(self, side, cat):
+        build = {}
+        if cat == 'p':
+            if side :
+                build = {'domain': {'this_partner_id': [('company_type','=', 'person')]}}
+            else:
+                build = {'domain': {'other_partner_id': [('company_type','=', 'person')]}}
+        if cat == 'c':
+            if side :
+                build = {'domain': {'this_partner_id': [('company_type','=', 'company')]}}
+            else:
+                build = {'domain': {'other_partner_id': [('company_type','=', 'company')]}}
+        if cat == 'fsm-location':
+            if side :
+                build = {'domain': {'this_partner_id': [('fsm_location','=', True)]}}
+            else:
+                build = {'domain': {'other_partner_id': [('fsm_location','=', True)]}}
+        return build
+
+    def get_cat(self, partner):
+        if partner.fsm_location:
+            return 'fsm-location'
+        elif partner.company_type == 'person':
+            return 'p'
+        else:
+            return 'c'

--- a/fieldservice_partner_multi_relation/models/res_partner_relation_all.py
+++ b/fieldservice_partner_multi_relation/models/res_partner_relation_all.py
@@ -113,7 +113,7 @@ class ResPartnerRelationAll(models.AbstractModel):
         if right_cat == 'fsm-location':
             if not right_to_test.fsm_location:
                 raise ValidationError(
-                        _('Right Partner not type FSM Location'))
+                    _('Right Partner not type FSM Location'))
 
     def set_domain_left(self):
         type_id = self.env['res.partner.relation.type'].\

--- a/fieldservice_partner_multi_relation/models/res_partner_relation_all.py
+++ b/fieldservice_partner_multi_relation/models/res_partner_relation_all.py
@@ -11,16 +11,18 @@ class ResPartnerRelationAll(models.AbstractModel):
     @api.onchange('this_partner_id')
     def onchange_this_partner_id(self):
         if self.this_partner_id:
-            type_id = self.env['res.partner.relation.type'].search([('name', '=', self.type_selection_id.name)])
+            type_id = self.env['res.partner.relation.type'].\
+                search([('name', '=', self.type_selection_id.name)])
             if (type_id.contact_type_left == 'fsm-location'
-            or type_id.contact_type_right == 'fsm-location'
-            or self.this_partner_id.fsm_location or self.other_partner_id.fsm_location):
+                    or type_id.contact_type_right == 'fsm-location'
+                    or self.this_partner_id.fsm_location
+                    or self.other_partner_id.fsm_location):
                 if not self.type_selection_id:
                     return self.set_domain_type()
             elif not self.this_partner_id:
                 if not self.other_partner_id:
                     return {'domain': {'type_selection_id': ''}}
-                
+
             else:
                 super(ResPartnerRelationAll, self).onchange_partner_id()
         else:
@@ -30,10 +32,12 @@ class ResPartnerRelationAll(models.AbstractModel):
     @api.onchange('other_partner_id')
     def onchange_other_partner_id(self):
         if self.other_partner_id:
-            type_id = self.env['res.partner.relation.type'].search([('name', '=', self.type_selection_id.name)])
+            type_id = self.env['res.partner.relation.type'].\
+                search([('name', '=', self.type_selection_id.name)])
             if (type_id.contact_type_left == 'fsm-location'
-            or type_id.contact_type_right == 'fsm-location'
-            or self.this_partner_id.fsm_location or self.other_partner_id.fsm_location):
+                    or type_id.contact_type_right == 'fsm-location'
+                    or self.this_partner_id.fsm_location
+                    or self.other_partner_id.fsm_location):
                 if not type_id:
                     return self.set_domain_type()
                 elif not self.other_partner_id:
@@ -50,11 +54,15 @@ class ResPartnerRelationAll(models.AbstractModel):
     def onchange_type_selection_id(self):
         # Clear any prexisting domains
         if not self.type_selection_id:
-            return {'domain': {'this_partner_id': [('id', '!=', None)], 'other_partner_id': [('id', '!=', None)]}}
-        type_id = self.env['res.partner.relation.type'].search([('name', '=', self.type_selection_id.name)])
+            return {'domain':
+                    {'this_partner_id': [('id', '!=', None)],
+                     'other_partner_id': [('id', '!=', None)]}}
+        type_id = self.env['res.partner.relation.type'].\
+            search([('name', '=', self.type_selection_id.name)])
         if (type_id.contact_type_left == 'fsm-location'
-        or type_id.contact_type_right == 'fsm-location'
-        or self.this_partner_id.fsm_location or self.other_partner_id.fsm_location):
+                or type_id.contact_type_right == 'fsm-location'
+                or self.this_partner_id.fsm_location
+                or self.other_partner_id.fsm_location):
             if self.this_partner_id and self.other_partner_id:
                 # Check
                 self.try_type()
@@ -67,16 +75,16 @@ class ResPartnerRelationAll(models.AbstractModel):
                 res = self.set_domain_left()
                 return res
             else:
-                res =  self.set_domain_left()
-                res2 =  self.set_domain_right()
+                res = self.set_domain_left()
+                res2 = self.set_domain_right()
                 res.update(res2['domain'])
                 return res
         else:
             super(ResPartnerRelationAll, self).onchange_type_selection_id()
 
-
     def try_type(self):
-        type_id = self.env['res.partner.relation.type'].search([('name', '=', self.type_selection_id.name)])
+        type_id = self.env['res.partner.relation.type'].\
+            search([('name', '=', self.type_selection_id.name)])
         # From Type
         left_cat = type_id.contact_type_left
         right_cat = type_id.contact_type_right
@@ -86,13 +94,13 @@ class ResPartnerRelationAll(models.AbstractModel):
         right_to_test = self.other_partner_id
 
         # Compare
-        if right_cat == 'p':
+        if left_cat == 'p':
             if left_to_test.company_type != 'person':
                 raise ValidationError(_('Left Partner not type Person'))
-        if right_cat == 'c':
+        if left_cat == 'c':
             if left_to_test.company_type != 'compnay':
                 raise ValidationError(_('Left Partner not type Company'))
-        if right_cat == 'fsm-location':
+        if left_cat == 'fsm-location':
             if not left_to_test.fsm_location:
                 raise ValidationError(_('Left Partner not type FSM Location'))
 
@@ -104,10 +112,12 @@ class ResPartnerRelationAll(models.AbstractModel):
                 raise ValidationError(_('Right Partner not type Company'))
         if right_cat == 'fsm-location':
             if not right_to_test.fsm_location:
-                raise ValidationError(_('Right Partner not type FSM Location'))
+                raise ValidationError(
+                        _('Right Partner not type FSM Location'))
 
     def set_domain_left(self):
-        type_id = self.env['res.partner.relation.type'].search([('name', '=', self.type_selection_id.name)])
+        type_id = self.env['res.partner.relation.type'].\
+            search([('name', '=', self.type_selection_id.name)])
         # From Type
         res = {}
         # With a Relation Type
@@ -121,7 +131,8 @@ class ResPartnerRelationAll(models.AbstractModel):
             res = {'domain': {'this_partner_id': ''}}
 
     def set_domain_right(self):
-        type_id = self.env['res.partner.relation.type'].search([('name', '=', self.type_selection_id.name)])
+        type_id = self.env['res.partner.relation.type'].\
+            search([('name', '=', self.type_selection_id.name)])
         # From Type
         res = {}
         # With a Relation Type
@@ -133,7 +144,7 @@ class ResPartnerRelationAll(models.AbstractModel):
         # Wtihout a Relation Type
         else:
             res = {'domain': {'other_partner_id': ''}}
-                        
+
     def set_domain_type(self):
         res = {}
         # If Left & Right then Type must match both
@@ -141,47 +152,63 @@ class ResPartnerRelationAll(models.AbstractModel):
             left_cat = self.get_cat(self.this_partner_id)
             right_cat = self.get_cat(self.other_partner_id)
             type_ids = self.env['res.partner.relation.type'].\
-                search([('contact_type_left', '=', left_cat), ('contact_type_right', '=', right_cat)])
+                search([('contact_type_left', '=', left_cat),
+                        ('contact_type_right', '=', right_cat)])
             type_names = []
             for type_id in type_ids:
                 type_names.append(type_id.name)
             # From Type
-            res = {'domain': {'type_selection_id': [('name', 'in', type_names)]}}
+            res = {'domain':
+                   {'type_selection_id': [('name', 'in', type_names)]}}
         # If Left Type must match Left
         elif self.this_partner_id:
             left_cat = self.get_cat(self.this_partner_id)
-            type_ids = self.env['res.partner.relation.type'].search([('contact_type_left', '=', left_cat)])
+            type_ids = self.env['res.partner.relation.type'].\
+                search([('contact_type_left', '=', left_cat)])
             type_names = []
             for type_id in type_ids:
                 type_names.append(type_id.name)
-            res = {'domain': {'type_selection_id': [('name', 'in', type_names)]}}
+            res = {'domain':
+                   {'type_selection_id': [('name', 'in', type_names)]}}
         # If Right Type must match Right
         elif self.other_partner_id:
             right_cat = self.get_cat(self.other_partner_id)
-            type_ids = self.env['res.partner.relation.type'].search([('contact_type_right', '=', right_cat)])
+            type_ids = self.env['res.partner.relation.type'].\
+                search([('contact_type_right', '=', right_cat)])
             type_names = []
             for type_id in type_ids:
                 type_names.append(type_id.name)
-            res = {'domain': {'type_selection_id': [('name', 'in', type_names)]}}
-        return res            
+            res = {'domain':
+                   {'type_selection_id': [('name', 'in', type_names)]}}
+        return res
 
     def build_domain(self, side, cat):
         build = {}
         if cat == 'p':
-            if side :
-                build = {'domain': {'this_partner_id': [('company_type','=', 'person')]}}
+            if side:
+                build = {'domain':
+                         {'this_partner_id':
+                          [('company_type', '=', 'person')]}}
             else:
-                build = {'domain': {'other_partner_id': [('company_type','=', 'person')]}}
+                build = {'domain':
+                         {'other_partner_id':
+                          [('company_type', '=', 'person')]}}
         if cat == 'c':
-            if side :
-                build = {'domain': {'this_partner_id': [('company_type','=', 'company')]}}
+            if side:
+                build = {'domain':
+                         {'this_partner_id':
+                          [('company_type', '=', 'company')]}}
             else:
-                build = {'domain': {'other_partner_id': [('company_type','=', 'company')]}}
+                build = {'domain':
+                         {'other_partner_id':
+                          [('company_type', '=', 'company')]}}
         if cat == 'fsm-location':
-            if side :
-                build = {'domain': {'this_partner_id': [('fsm_location','=', True)]}}
+            if side:
+                build = {'domain':
+                         {'this_partner_id': [('fsm_location', '=', True)]}}
             else:
-                build = {'domain': {'other_partner_id': [('fsm_location','=', True)]}}
+                build = {'domain':
+                         {'other_partner_id': [('fsm_location', '=', True)]}}
         return build
 
     def get_cat(self, partner):


### PR DESCRIPTION
This PR integrates FSM Locations into the Partner Multi Relations module. This module only runs when one of the three fields in a relation type (left, type, right) are connected to an FSM Location. If none of them are, then the base logic handles the relation type. 

When an FSM Location is selected in one of the three, then domains are set to help make sure the user can only select partners or relationships that are compatible. This module requires one small change in workflow and that is relation types must have unique names. 

The base module you can selected relationship types with the same names but different relationships however the user then must guess that relationships left and right partner which I do not believe is ideal. The relationship types in the data are all prefixed with which categories should be on the left partner and the right partner.