### PR TITLE
[IMP] fieldservice: Support multiple equipments on service request

### DIFF
--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -86,8 +86,7 @@
                                    groups="fieldservice.group_fsm_team"/>
                             <field name="person_id"/>
                             <field name="equipment_id"
-                                attrs="{'required': [('type', 'in', ['repair', 'maintenance'])],
-                                        'invisible':[('type', 'not in',['repair', 'maintenance'])]}"
+                                attrs="{'invisible':[('type', 'not in',['repair', 'maintenance'])]}"
                                 groups="fieldservice.group_fsm_equipment"
                                 options="{'no_create': True}"
                                 domain="[('current_location_id','=',location_id)]"/>

--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -159,11 +159,11 @@
                                 <group id="execution-right"/>
                             </group>
                         </page>
-                        <page string="Equipment"
+                        <page string="Equipments"
+                            groups="fieldservice.group_fsm_equipment"
                             attrs="{'invisible': [('type', 'in', ['repair', 'maintenance'])]}">
                             <field name="equipment_ids"
                                    attrs="{'required': [('type', 'not in', ['repair', 'maintenance'])]}"
-                                   groups="fieldservice.group_fsm_equipment"
                                    options="{'no_create': True}"
                                    domain="[('current_location_id','=',location_id)]">
                                 <tree>

--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -82,14 +82,15 @@
                             <field name="district_id" invisible='1'/>
                             <field name="region_id" invisible='1'/>
                             <field name="customer_id"/>
-                            <field name="equipment_id"
-                                   attrs="{'required': [('type', '!=', False)]}"
-                                   groups="fieldservice.group_fsm_equipment"
-                                   options="{'no_create': True}"
-                                   domain="[('current_location_id','=',location_id)]"/>
                             <field name="team_id"
                                    groups="fieldservice.group_fsm_team"/>
-                            <field name="person_id" context="{'search_default_location_ids': location_id}"/>
+                            <field name="person_id"/>
+                            <field name="equipment_id"
+                                attrs="{'required': [('type', 'in', ['repair', 'maintenance'])],
+                                        'invisible':[('type', 'not in',['repair', 'maintenance'])]}"
+                                groups="fieldservice.group_fsm_equipment"
+                                options="{'no_create': True}"
+                                domain="[('current_location_id','=',location_id)]"/>
                         </group>
                     </group>
                     <group string="Description">
@@ -157,6 +158,20 @@
                                 </group>
                                 <group id="execution-right"/>
                             </group>
+                        </page>
+                        <page string="Equipment"
+                            attrs="{'invisible': [('type', 'in', ['repair', 'maintenance'])]}">
+                            <field name="equipment_ids"
+                                   attrs="{'required': [('type', 'not in', ['repair', 'maintenance'])]}"
+                                   groups="fieldservice.group_fsm_equipment"
+                                   options="{'no_create': True}"
+                                   domain="[('current_location_id','=',location_id)]">
+                                <tree>
+                                    <field name="name"/>
+                                    <field name="person_id"/>
+                                    <field name="location_id"/>
+                                </tree>
+                            </field>
                         </page>
                     </notebook>
                 </sheet>

--- a/fieldservice_maintenance/models/fsm_order.py
+++ b/fieldservice_maintenance/models/fsm_order.py
@@ -11,30 +11,3 @@ class FSMOrder(models.Model):
     type = fields.Selection(selection_add=[('maintenance', 'Maintenance')])
     request_id = fields.Many2one(
         'maintenance.request', 'Maintenance Request')
-
-    @api.model
-    def create(self, vals):
-        # if FSM order with type maintenance is create then
-        # create maintenance request
-        order = super(FSMOrder, self).create(vals)
-        if order.type == 'maintenance':
-            employee_rec = self.env['hr.employee'].search(
-                [('user_id', '=', self.env.uid)], limit=1)
-            if order.equipment_id and not order.request_id:
-                equipment = order.equipment_id
-                team_id = equipment.maintenance_equipment_id and\
-                    equipment.maintenance_equipment_id.maintenance_team_id.id
-                request_id = self.env['maintenance.request'].with_context(
-                    fsm_order=True).create({
-                        'name': order.name or '',
-                        'employee_id': employee_rec.id,
-                        'equipment_id': equipment.maintenance_equipment_id.id,
-                        'category_id': equipment.category_id.id,
-                        'request_date': fields.Date.context_today(self),
-                        'maintenance_type': 'corrective',
-                        'maintenance_team_id': team_id,
-                        'schedule_date': order.request_early,
-                        'description': order.description
-                    })
-                order.request_id = request_id
-        return order

--- a/fieldservice_maintenance/models/fsm_order.py
+++ b/fieldservice_maintenance/models/fsm_order.py
@@ -11,3 +11,30 @@ class FSMOrder(models.Model):
     type = fields.Selection(selection_add=[('maintenance', 'Maintenance')])
     request_id = fields.Many2one(
         'maintenance.request', 'Maintenance Request')
+        
+    # @api.model
+    # def create(self, vals):
+    #     # if FSM order with type maintenance is create then
+    #     # create maintenance request
+    #     order = super(FSMOrder, self).create(vals)
+    #     if order.type == 'maintenance':
+    #         employee_rec = self.env['hr.employee'].search(
+    #             [('user_id', '=', self.env.uid)], limit=1)
+    #         if order.equipment_id and not order.request_id:
+    #             equipment = order.equipment_id
+    #             team_id = equipment.maintenance_equipment_id and\
+    #                 equipment.maintenance_equipment_id.maintenance_team_id.id
+    #             request_id = self.env['maintenance.request'].with_context(
+    #                 fsm_order=True).create({
+    #                     'name': order.name or '',
+    #                     'employee_id': employee_rec.id,
+    #                     'equipment_id': equipment.maintenance_equipment_id.id,
+    #                     'category_id': equipment.category_id.id,
+    #                     'request_date': fields.Date.context_today(self),
+    #                     'maintenance_type': 'corrective',
+    #                     'maintenance_team_id': team_id,
+    #                     'schedule_date': order.request_early,
+    #                     'description': order.description
+    #                 })
+    #             order.request_id = request_id
+    #     return order

--- a/fieldservice_repair/models/fsm_order.py
+++ b/fieldservice_repair/models/fsm_order.py
@@ -11,3 +11,33 @@ class FSMOrder(models.Model):
     type = fields.Selection(selection_add=[('repair', 'Repair')])
     repair_id = fields.Many2one(
         'repair.order', 'Repair Order')
+
+    # @api.model
+    # def create(self, vals):
+    #     # if FSM order with type repair is created then
+    #     # create a repair order
+    #     order = super(FSMOrder, self).create(vals)
+    #     if order.type == 'repair':
+    #         if (order.equipment_id and
+    #                 order.equipment_id.current_stock_location_id):
+    #             equipment = order.equipment_id
+    #             repair_id = self.env['repair.order'].create({
+    #                 'name': order.name or '',
+    #                 'product_id': equipment.product_id.id or False,
+    #                 'product_uom': equipment.product_id.uom_id.id or False,
+    #                 'location_id':
+    #                     equipment.current_stock_location_id and
+    #                     equipment.current_stock_location_id.id or False,
+    #                 'lot_id': equipment.lot_id.id or '',
+    #                 'product_qty': 1,
+    #                 'invoice_method': 'none',
+    #                 'internal_notes': order.description,
+    #                 'partner_id':
+    #                     order.customer_id and order.customer_id.id or False,
+    #             })
+    #             order.repair_id = repair_id
+    #         elif not order.equipment_id.current_stock_location_id:
+    #             raise ValidationError(_("Cannot create Repair Order because "
+    #                                     "Equipment does not have a Current "
+    #                                     "Inventory Location."))
+    #     return order

--- a/fieldservice_repair/models/fsm_order.py
+++ b/fieldservice_repair/models/fsm_order.py
@@ -11,33 +11,3 @@ class FSMOrder(models.Model):
     type = fields.Selection(selection_add=[('repair', 'Repair')])
     repair_id = fields.Many2one(
         'repair.order', 'Repair Order')
-
-    @api.model
-    def create(self, vals):
-        # if FSM order with type repair is created then
-        # create a repair order
-        order = super(FSMOrder, self).create(vals)
-        if order.type == 'repair':
-            if (order.equipment_id and
-                    order.equipment_id.current_stock_location_id):
-                equipment = order.equipment_id
-                repair_id = self.env['repair.order'].create({
-                    'name': order.name or '',
-                    'product_id': equipment.product_id.id or False,
-                    'product_uom': equipment.product_id.uom_id.id or False,
-                    'location_id':
-                        equipment.current_stock_location_id and
-                        equipment.current_stock_location_id.id or False,
-                    'lot_id': equipment.lot_id.id or '',
-                    'product_qty': 1,
-                    'invoice_method': 'none',
-                    'internal_notes': order.description,
-                    'partner_id':
-                        order.customer_id and order.customer_id.id or False,
-                })
-                order.repair_id = repair_id
-            elif not order.equipment_id.current_stock_location_id:
-                raise ValidationError(_("Cannot create Repair Order because "
-                                        "Equipment does not have a Current "
-                                        "Inventory Location."))
-        return order


### PR DESCRIPTION
This PR allows users to add multiple Equipment on a Service Request. It is important to note that only 1 Equipment can be used on a Repair Order or Maintenance Order. So when those are selected, we hide the Many2many field and make the user select 1 Equipment.