### PR TITLE
[IMP] fieldservice_geoengine: Add calendar view

### DIFF
--- a/fieldservice_geoengine/views/fsm_order.xml
+++ b/fieldservice_geoengine/views/fsm_order.xml
@@ -26,7 +26,7 @@
         <field name="name">Orders</field>
         <field name="res_model">fsm.order</field>
         <field name="view_type">form</field>
-        <field name="view_mode">kanban,timeline,tree,geoengine,form</field>
+        <field name="view_mode">kanban,timeline,tree,geoengine,calendar,form</field>
         <field name="search_view_id" ref="fieldservice.fsm_order_search_view"/>
         <field name="help" type="html">
             <p class="oe_view_nocontent_create">


### PR DESCRIPTION
Adds calendar to fieldservice_geoengine action so the calendar in fieldservice is not overwritten.