### PR TITLE
[IMP] fieldservice: onchange_scheduled_date_end

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -182,20 +182,12 @@ class FSMOrder(models.Model):
                          'request_early': str(req_date)})
         return super(FSMOrder, self).create(vals)
 
-    @api.onchange('scheduled_duration')
-    def _onchange_scheduled_duration(self):
-        if self.scheduled_date_start:
+    @api.onchange('scheduled_date_start', 'scheduled_duration')
+    def _onchange_scheduled_date_end(self):
+        if self.scheduled_date_start and self.duration:
             self.scheduled_date_end = fields.Datetime.\
                 from_string((self.scheduled_date_start) +
                             timedelta(hours=self.scheduled_duration))
-
-    @api.onchange('scheduled_date_start')
-    def _onchange_scheduled_date_start(self):
-        if self.scheduled_date_start:
-            if self.scheduled_duration:
-                self.scheduled_date_end = fields.Datetime.\
-                    from_string((self.scheduled_date_start) +
-                                timedelta(hours=self.scheduled_duration))
 
     @api.multi
     def write(self, vals):

--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -184,7 +184,7 @@ class FSMOrder(models.Model):
 
     @api.onchange('scheduled_date_start', 'scheduled_duration')
     def _onchange_scheduled_date_end(self):
-        if self.scheduled_date_start and self.duration:
+        if self.scheduled_date_start and self.scheduled_duration:
             self.scheduled_date_end = fields.Datetime.\
                 from_string((self.scheduled_date_start) +
                             timedelta(hours=self.scheduled_duration))

--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -124,8 +124,7 @@
                                             %(fieldservice.fsm_stage_started)d,
                                             %(fieldservice.fsm_stage_completed)d))]}"/>
                                     <field name="scheduled_duration"/>
-                                    <field name="scheduled_date_end"
-                                           readonly="1"/>
+                                    <field name="scheduled_date_end"/>
                                 </group>
                             </group>
                             <group string="Request Workers">

--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -124,7 +124,8 @@
                                             %(fieldservice.fsm_stage_started)d,
                                             %(fieldservice.fsm_stage_completed)d))]}"/>
                                     <field name="scheduled_duration"/>
-                                    <field name="scheduled_date_end"/>
+                                    <field name="scheduled_date_end"
+                                           readonly="1"/>
                                 </group>
                             </group>
                             <group string="Request Workers">


### PR DESCRIPTION
Scheduled_date_start, scheduled_date_end, and scheduled_duration were call computed together whenever one was edited. This is too restrictive, this PR sets scheduled_date_end when the scheduled_duration or scheduled_date_start is changed however if the user wants to edit the start or end date they can.