### PR TITLE
[IMP] fieldservice_stock: Add FSM to Stock Requests, Hide Routes, Only Submit Draft Requests

### DIFF
--- a/fieldservice_stock/__manifest__.py
+++ b/fieldservice_stock/__manifest__.py
@@ -23,6 +23,7 @@
         'views/fsm_equipment.xml',
         'views/product_template.xml',
         'views/stock_production_lot.xml',
+        'views/stock_request.xml'
     ],
     'license': 'AGPL-3',
     'development_status': 'Beta',

--- a/fieldservice_stock/models/__init__.py
+++ b/fieldservice_stock/models/__init__.py
@@ -8,5 +8,6 @@ from . import (
     fsm_equipment,
     product_template,
     stock_production_lot,
-    fsm_wizard
+    fsm_wizard,
+    stock_request
 )

--- a/fieldservice_stock/models/fsm_order.py
+++ b/fieldservice_stock/models/fsm_order.py
@@ -51,7 +51,8 @@ class FSMOrder(models.Model):
             if not rec.stock_request_ids:
                 raise UserError(_('Please create a stock request.'))
             for line in rec.stock_request_ids:
-                line.action_confirm()
+                if line.state == 'draft':
+                    line.action_confirm()
             rec.request_stage = 'submitted'
 
     def action_request_cancel(self):

--- a/fieldservice_stock/models/stock.py
+++ b/fieldservice_stock/models/stock.py
@@ -44,8 +44,10 @@ class StockMoveLine(models.Model):
         for rec in self:
             if rec.move_id and rec.move_id.allocation_ids:
                 for request in rec.move_id.allocation_ids:
-                    if request.state == 'done' and request.fsm_order_id:
-                        request.fsm_order_id.request_stage = 'done'
+                    if (request.stock_request_id.state == 'done'
+                            and request.stock_request_id.fsm_order_id):
+                        request.stock_request_id.\
+                            fsm_order_id.request_stage = 'done'
         return res
 
 
@@ -58,8 +60,8 @@ class StockMove(models.Model):
             'product_id': move_line.product_id.id,
             'lot_id': move_line.lot_id.id,
             'current_location_id':
-            move_line.request_id.fsm_order_id.location_id.id,
-            'current_stock_location_id': move_line.dest_location_id.id}
+            move_line.move_id.stock_request_ids.fsm_order_id.location_id.id,
+            'current_stock_location_id': move_line.location_dest_id.id}
 
     def _action_done(self):
         res = False

--- a/fieldservice_stock/models/stock_request.py
+++ b/fieldservice_stock/models/stock_request.py
@@ -1,0 +1,10 @@
+# Copyright (C) 2019 - TODAY, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class StockRequest(models.Model):
+    _inherit = 'stock.request'
+
+    fsm_order_id = fields.Many2one('fsm.order', string="FSM Order")

--- a/fieldservice_stock/views/fsm_order.xml
+++ b/fieldservice_stock/views/fsm_order.xml
@@ -54,7 +54,8 @@
                             <field name="direction" required="1"/>
                             <field name="route_id"
                                    options="{'no_create': True}"
-                                   groups="stock.group_stock_multi_locations"/>
+                                   groups="stock.group_stock_multi_locations"
+                                   invisible="1"/>
                             <field name="route_ids" invisible="1"/>
                             <field name="product_uom_qty"/>
                             <field name="qty_in_progress"/>

--- a/fieldservice_stock/views/stock_request.xml
+++ b/fieldservice_stock/views/stock_request.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="stock_request_fsm_order" model="ir.ui.view">
+        <field name="model">stock.request</field>
+        <field name="inherit_id" ref="stock_request.view_stock_request_form"/>
+        <field name="arch" type="xml">
+            <field name="picking_policy" position="after">
+                <field name="fsm_order_id"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This PR adds FSM Order to Stock Requests, hides Routes on FSM Orders, and prevents Orders that are finished from being submitted. Only requests in Draft state should be submitted.