### PR TITLE
[FIX] fieldservice_geoengine: Add Calendar to Team Order View

### DIFF
--- a/fieldservice_geoengine/views/fsm_team.xml
+++ b/fieldservice_geoengine/views/fsm_team.xml
@@ -4,7 +4,7 @@
     <record id="fieldservice.fsm_order_action_from_dashboard" model="ir.actions.act_window">
         <field name="name">Orders</field>
         <field name="res_model">fsm.order</field>
-        <field name="view_mode">kanban,timeline,tree,geoengine,form</field>
+        <field name="view_mode">kanban,timeline,tree,geoengine,form,calendar</field>
         <field name="context">{'default_team_id': active_id}</field>
         <field name="domain">[('team_id', '=', active_id)]</field>
     </record>


### PR DESCRIPTION
fieldservice_geoengine > views > fsm_team.xml was overwriting our action without adding calendar to "view_mode"