### PR TITLE
[12.0][FIX] fieldservice_recurring: Add missing fields to prepare

### DIFF
--- a/fieldservice_recurring/models/fsm_recurring.py
+++ b/fieldservice_recurring/models/fsm_recurring.py
@@ -152,6 +152,10 @@ class FSMRecurringOrder(models.Model):
             'request_early': str(earliest_date),
             'description': self.description,
             'template_id': self.fsm_order_template_id.id,
+            'scheduled_duration': self.fsm_order_template_id.hours,
+            'category_ids': [(
+                6, False,
+                self.fsm_order_template_id.category_ids.ids)],
             # 'company_id': self.company_id.id,
         }
 


### PR DESCRIPTION
Hours (duration) and categories should be copied from the template to the order