### PR TITLE
[12.0][FIX]fieldservice calc scheduled dates and duration

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -199,19 +199,19 @@ class FSMOrder(models.Model):
             req_date = req_date.replace(minute=0, second=0)
             vals.update({'scheduled_date_start': str(req_date),
                          'request_early': str(req_date)})
-        self._cacl_scheduled_dates(vals)
+        self._calc_scheduled_dates(vals)
         return super(FSMOrder, self).create(vals)
 
     @api.multi
     def write(self, vals):
-        self._cacl_scheduled_dates(vals)
+        self._calc_scheduled_dates(vals)
         res = super(FSMOrder, self).write(vals)
         for order in self:
             if 'customer_id' not in vals and order.customer_id is False:
                 order.customer_id = order.location_id.customer_id.id
         return res
 
-    def _cacl_scheduled_dates(self, vals):
+    def _calc_scheduled_dates(self, vals):
         """Calculate scheduled dates and duration"""
         if 'scheduled_date_end' in vals:
             date_to_with_delta = fields.Datetime.from_string(

--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -199,19 +199,20 @@ class FSMOrder(models.Model):
             req_date = req_date.replace(minute=0, second=0)
             vals.update({'scheduled_date_start': str(req_date),
                          'request_early': str(req_date)})
-        self._cacl_scheduled_duration_or_end(vals)
+        self._cacl_scheduled_dates(vals)
         return super(FSMOrder, self).create(vals)
 
     @api.multi
     def write(self, vals):
-        self._cacl_scheduled_duration_or_end(vals)
+        self._cacl_scheduled_dates(vals)
         res = super(FSMOrder, self).write(vals)
         for order in self:
             if 'customer_id' not in vals and order.customer_id is False:
                 order.customer_id = order.location_id.customer_id.id
         return res
 
-    def _cacl_scheduled_duration_or_end(self, vals):
+    def _cacl_scheduled_dates(self, vals):
+        """Calculate scheduled dates and duration"""
         if 'scheduled_date_end' in vals:
             date_to_with_delta = fields.Datetime.from_string(
                 vals.get('scheduled_date_end')) - \

--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -199,10 +199,19 @@ class FSMOrder(models.Model):
             req_date = req_date.replace(minute=0, second=0)
             vals.update({'scheduled_date_start': str(req_date),
                          'request_early': str(req_date)})
+        self._cacl_scheduled_duration_or_end(vals)
         return super(FSMOrder, self).create(vals)
 
     @api.multi
     def write(self, vals):
+        self._cacl_scheduled_duration_or_end(vals)
+        res = super(FSMOrder, self).write(vals)
+        for order in self:
+            if 'customer_id' not in vals and order.customer_id is False:
+                order.customer_id = order.location_id.customer_id.id
+        return res
+
+    def _cacl_scheduled_duration_or_end(self, vals):
         if 'scheduled_date_end' in vals:
             date_to_with_delta = fields.Datetime.from_string(
                 vals.get('scheduled_date_end')) - \
@@ -219,11 +228,6 @@ class FSMOrder(models.Model):
                     vals.get('scheduled_date_start')) + \
                     timedelta(hours=self.scheduled_duration)
                 vals['scheduled_date_end'] = str(date_to_with_delta)
-        res = super(FSMOrder, self).write(vals)
-        for order in self:
-            if 'customer_id' not in vals and order.customer_id is False:
-                order.customer_id = order.location_id.customer_id.id
-        return res
 
     def action_confirm(self):
         return self.write({'stage_id': self.env.ref(


### PR DESCRIPTION
Before this PR:
when an order is created with schedule_date_start + duration, the schedule_date_end is not calculated.

After :
the behaviour is consistent across create() and write()