### PR TITLE
[12.0] fieldservice fsm.order Fix inheritance on default=

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -47,7 +47,7 @@ class FSMOrder(models.Model):
                                help="Classify and analyze your orders")
     color = fields.Integer('Color Index', default=0)
     team_id = fields.Many2one('fsm.team', string='Team',
-                              default=_default_team_id,
+                              default=lambda self: self._default_team_id(),
                               index=True, required=True,
                               track_visibility='onchange')
 

--- a/fieldservice/models/fsm_team.py
+++ b/fieldservice/models/fsm_team.py
@@ -76,4 +76,5 @@ class FSMStage(models.Model):
 
     team_ids = fields.Many2many(
         'fsm.team', 'order_team_stage_rel', 'stage_id', 'team_id',
-        string='Teams', default=_default_team_ids)
+        string='Teams',
+        default=lambda self: self._default_team_ids())


### PR DESCRIPTION
We can't inherit a method defined on field.default.

Consistent with stage_id few lines above.