### PR TITLE
WIP [IMP] fieldservice_recurring: Add helper with planned_hour precision

### DIFF
--- a/fieldservice_recurring/models/fsm_frequency.py
+++ b/fieldservice_recurring/models/fsm_frequency.py
@@ -44,6 +44,15 @@ WEEKDAYS_SELECT = [
     ("su", "SU"),
 ]
 
+FREQUENCIES = [
+    ("1", "First"),
+    ("2", "Second"),
+    ("3", "Third"),
+    ("4", "Forth"),
+    ("5", "last"),
+    ("6", "Each"),
+]
+
 
 class FSMFrequency(models.Model):
     _name = 'fsm.frequency'
@@ -109,9 +118,40 @@ class FSMFrequency(models.Model):
     use_rrulestr = fields.Boolean(string="Use rrule string")
     rrule_string = fields.Char()
     # simlpe edit helper with planned_hour precision
+    interval_frequency = fields.Selection(FREQUENCIES, string="Interval Frequency")
     use_planned_hour = fields.Boolean()
     week_day = fields.Selection(WEEKDAYS_SELECT, string="Week Day")
     planned_hour = fields.Float("Planned Hours")
+
+    @api.onchange("interval_frequency")
+    def _onchange_interval_frequency(self):
+        """
+        Set corresponding interval_type and set_pos
+        """
+        for freq in self:
+            if not freq.interval_frequency:
+                freq.use_planned_hour = False 
+                continue
+            freq.interval_type = "monthly"
+            freq.use_planned_hour = True
+            freq.set_pos = 0
+            if freq.interval_frequency == "6":
+                freq.interval_type = "weekly"
+            elif freq.interval_frequency == "5":
+                freq.set_pos = -1
+            else:
+                freq.set_pos = int(freq.interval_frequency)
+
+    @api.model
+    def create(self, vals):
+        if not vals.get('name'):
+            hours, minutes = self._split_time_to_hour_min(
+                vals.get('planned_hour')
+            )
+            wd = _(dict(WEEKDAYS_SELECT)[ vals.get('week_day')])
+            name = wd + "_" + str(hours) + "_" + str(minutes)
+            vals['name'] = name
+        return super(FSMFrequency, self).create(vals)
 
     @api.onchange("week_day")
     def _onchange_week_day(self):

--- a/fieldservice_recurring/models/fsm_frequency.py
+++ b/fieldservice_recurring/models/fsm_frequency.py
@@ -1,13 +1,25 @@
 # Copyright (C) 2019 - TODAY, Brian McMaster, Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from dateutil.rrule import MO, TU, WE, TH, FR, SA, SU
-from dateutil.rrule import YEARLY, MONTHLY, WEEKLY, DAILY
-from dateutil.rrule import rrule
+from dateutil.rrule import (
+    DAILY,
+    FR,
+    MO,
+    MONTHLY,
+    SA,
+    SU,
+    TH,
+    TU,
+    WE,
+    WEEKLY,
+    YEARLY,
+    rrule,
+)
 
 from odoo import fields, models, api, _
 from odoo.exceptions import UserError
 
+WEEKDAYS = {"mo": MO, "tu": TU, "we": WE, "th": TH, "fr": FR, "sa": SA, "su": SU}
 
 WEEKDAYS = {
     'mo': MO,
@@ -144,13 +156,11 @@ class FSMFrequency(models.Model):
 
     @api.model
     def create(self, vals):
-        if not vals.get('name'):
-            hours, minutes = self._split_time_to_hour_min(
-                vals.get('planned_hour')
-            )
-            wd = _(dict(WEEKDAYS_SELECT)[ vals.get('week_day')])
+        if not vals.get("name"):
+            hours, minutes = self._split_time_to_hour_min(vals.get("planned_hour"))
+            wd = _(dict(WEEKDAYS_SELECT)[vals.get("week_day")])
             name = wd + "_" + str(hours) + "_" + str(minutes)
-            vals['name'] = name
+            vals["name"] = name
         return super(FSMFrequency, self).create(vals)
 
     @api.onchange("week_day")

--- a/fieldservice_recurring/models/fsm_frequency_set.py
+++ b/fieldservice_recurring/models/fsm_frequency_set.py
@@ -38,3 +38,22 @@ class FSMFrequencySet(models.Model):
             else:
                 rset.exrule(rule._get_rrule(dtstart))
         return rset
+
+    def _update_frequency_set(self, vals):
+        if vals.get("fsm_frequency_ids"):
+            if self.exists() and self.fsm_frequency_set_id:
+                self.fsm_frequency_set_id.fsm_frequency_ids = vals.get(
+                    "fsm_frequency_ids"
+                )
+            else:
+                freq_vals = {
+                    "name": name,
+                    "use_planned_hour": True,
+                    "week_day": self.week_day,
+                    "planned_hour": self.planned_hour,
+                    "interval_type": interval_type,
+                    "set_pos": set_pos,
+                }
+                print(freq_vals)
+                freq = self.env["fsm.frequency"].create(freq_vals)
+                self.fsm_frequency_ids = (4, freq.id)

--- a/fieldservice_recurring/views/fsm_frequency.xml
+++ b/fieldservice_recurring/views/fsm_frequency.xml
@@ -50,19 +50,28 @@
                             </group>
                             <div attrs="{'invisible': [('use_byweekday', '=', False)]}" name="weekdays">
                                 <group>
-                                    <field name="mo"/>
-                                    <field name="tu"/>
-                                    <field name="we"/>
-                                    <field name="th"/>
-                                    <field name="fr"/>
-                                    <field name="sa"/>
-                                    <field name="su"/>
+                                    <field name="use_planned_hour"/>
                                 </group>
-                            </div>
-                            <group>
-                                <field name="use_bymonthday"/>
-                            </group>
-                            <div attrs="{'invisible': [('use_bymonthday', '=', False)]}" name="monthday">
+                                <div attrs="{'invisible': [('use_planned_hour', '=', False)]}" name="hours">
+                                    <group>
+                                        <field name="week_day"/>
+                                        <field name="planned_hour" widget="float_time"/>
+                                    </group>
+                                <group>
+                                    <field name="use_byweekday"/>
+                                </group>
+                                <div attrs="{'invisible': [('use_byweekday', '=', False)]}" name="weekdays">
+                                    <group>
+                                        <field name="mo"/>
+                                        <field name="tu"/>
+                                        <field name="we"/>
+                                        <field name="th"/>
+                                        <field name="fr"/>
+                                        <field name="sa"/>
+                                        <field name="su"/>
+                                    </group>
+                                </div>
+                                </div>
                                 <group>
                                     <field name="month_day"/>
                                 </group>
@@ -97,7 +106,6 @@
                                 </group>
                             </div>
                         </div>
-                        
                     </group>
                 </sheet>
             </form>

--- a/fieldservice_recurring/views/fsm_recurring.xml
+++ b/fieldservice_recurring/views/fsm_recurring.xml
@@ -62,8 +62,7 @@
                             <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                         </group>
                         <group>
-                            <div attrs="{'invisible': [('frequency_type', '=', 'use_predefined')]}" name="weekdays"
-                                class="oe_edit_only">
+                            <div attrs="{'invisible': [('frequency_type', '=', 'use_predefined')]}" name="weekdays">
                                   <field name="fsm_frequency_ids" widget="one2many_list">
                                     <tree editable="bottom">
                                         <field name="interval_frequency"/>

--- a/fieldservice_recurring/views/fsm_recurring.xml
+++ b/fieldservice_recurring/views/fsm_recurring.xml
@@ -64,19 +64,13 @@
                         <group>
                             <div attrs="{'invisible': [('frequency_type', '=', 'use_predefined')]}" name="weekdays"
                                 class="oe_edit_only">
-                                <field name="interval_frequency"/>
-                                <field name="week_day"/>
-                                <field name="planned_hour"/>
-                                <button id="action_add_frequency"
-                                    name="action_add_frequency" string="Add Frequency"
-                                    class="oe_highlight oe_edit_only"
-                                    type="object" groups="fieldservice.group_fsm_dispatcher"
-                                    attrs="{'invisible': [('state', '!=', 'draft')]}"/>
-                                <field name="fsm_frequency_ids">
-                                    <tree create="false">
-                                        <field name="set_pos"/>
+                                  <field name="fsm_frequency_ids" widget="one2many_list">
+                                    <tree editable="bottom">
+                                        <field name="interval_frequency"/>
                                         <field name="week_day"/>
                                         <field name="planned_hour" widget="float_time"/>
+                                        <field name="interval_type" invisible="1"/>
+                                        <field name="use_planned_hour" invisible="1"/>
                                     </tree>
                                 </field>
                             </div>

--- a/fieldservice_recurring/views/fsm_recurring.xml
+++ b/fieldservice_recurring/views/fsm_recurring.xml
@@ -48,7 +48,10 @@
                     <group>
                         <group>
                             <field name="fsm_order_template_id" groups="fieldservice.group_fsm_template"/>
-                            <field name="fsm_frequency_set_id"/>
+                                <field name="frequency_type"/>
+                             <field name="fsm_frequency_set_id"
+                                attrs="{'invisible': [('frequency_type', '!=', 'use_predefined')],
+                               'required': [('frequency_type', '=', 'use_predefined')] }"/>
                             <field name="start_date"/>
                             <field name="end_date"/>
                             <field name="max_orders"/>
@@ -57,6 +60,26 @@
                             <field name="fsm_recurring_template_id"/>
                             <field name="location_id"/>
                             <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                        </group>
+                        <group>
+                            <div attrs="{'invisible': [('frequency_type', '=', 'use_predefined')]}" name="weekdays"
+                                class="oe_edit_only">
+                                <field name="interval_frequency"/>
+                                <field name="week_day"/>
+                                <field name="planned_hour"/>
+                                <button id="action_add_frequency"
+                                    name="action_add_frequency" string="Add Frequency"
+                                    class="oe_highlight oe_edit_only"
+                                    type="object" groups="fieldservice.group_fsm_dispatcher"
+                                    attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                                <field name="fsm_frequency_ids">
+                                    <tree create="false">
+                                        <field name="set_pos"/>
+                                        <field name="week_day"/>
+                                        <field name="planned_hour" widget="float_time"/>
+                                    </tree>
+                                </field>
+                            </div>
                         </group>
                     </group>
                     <group string="Orders">


### PR DESCRIPTION
Add a possibility to add fsm.frequency from fsm.recurring. With this improvement we can add directly on recurring the following frequency example:
Each Monday a 10:30 and
Each second Thursday at 16:00 and 
Each last Friday at 14:30
Add frequencies will create frequency set and attach it to the recurring.


Principal additions:
* Field added on fsm.frequency
 use_planned_hour = fields.Boolean()
planned_hour = fields.Float("Planned Hours")

* view off fsm.recurring:
`                            <div attrs="{'invisible': [('frequency_type', '=', 'use_predefined')]}" name="weekdays"
                                class="oe_edit_only">
                                <field name="interval_frequency"/>
                                <field name="week_day"/>
                                <field name="planned_hour"/>
                                <button id="action_add_frequency"
                                    name="action_add_frequency" string="Add Frequency"
                                    class="oe_highlight oe_edit_only"
                                    type="object" groups="fieldservice.group_fsm_dispatcher"
                                    attrs="{'invisible': [('state', '!=', 'draft')]}"/>
                                <field name="fsm_frequency_ids">
                                    <tree create="false">
                                        <field name="set_pos"/>
                                        <field name="week_day"/>
                                        <field name="planned_hour" widget="float_time"/>
                                    </tree>
                                </field>
`
