### PR TITLE
[12.0][Fieldservice] Fix order of imports

### DIFF
--- a/fieldservice/__manifest__.py
+++ b/fieldservice/__manifest__.py
@@ -44,8 +44,8 @@
         'views/fsm_equipment.xml',
         'views/fsm_template.xml',
         'views/fsm_team.xml',
-        'views/menu.xml',
         'views/fsm_order_type.xml',
+        'views/menu.xml',
         'wizard/fsm_wizard.xml',
     ],
     'demo': [


### PR DESCRIPTION
Fixes error at installatio

`raise ValueError('External ID not found in the system: %s' % xmlid)
odoo.tools.convert.ParseError: "External ID not found in the system: fieldservice.action_fsm_order_type" while parsing /odoo/links/fieldservice/views/menu.xml:163, near
<menuitem id="menu_fsm_order_type" name="Order Types" action="action_fsm_order_type" parent="menu_fsm_config_order" sequence="30" groups="fieldservice.group_fsm_manager"/>
`

