### PR TITLE
[FIX] Unassigned Unscheduled Order Filters

### DIFF
--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -284,6 +284,12 @@
                 <filter string="To Do"
                         domain="[('stage_id.is_closed', '=', False)]"
                         name="todo"/>
+                <filter string="Unassigned"
+                        domain="[('person_id', '=', False)]"
+                        name="unassigned"/>
+                <filter string="Unscheduled"
+                        domain="[('scheduled_date_start', '=', False)]"
+                        name="unscheduled"/>
                 <filter string="Done"
                         domain="[('stage_id.is_closed', '=', True)]"
                         name="done"/>

--- a/fieldservice_isp_flow/views/fsm_order.xml
+++ b/fieldservice_isp_flow/views/fsm_order.xml
@@ -95,15 +95,6 @@
                ref="fieldservice.fsm_order_search_view"/>
         <field name="arch" type="xml">
             <search string="Orders">
-                
-                <filter name="todo" position="after">
-                    <filter string="Unassigned"
-                            domain="[('person_id', '=', False)]"
-                            name="unassigned"/>
-                    <filter string="Unscheduled"
-                            domain="[('scheduled_date_start', '=', False)]"
-                            name="unscheduled"/>
-                </filter>
                 <filter name="order_today" position="before">
                     <filter string="Past Due Orders"
                             domain="[('stage_id.name', 'not in', ['Started', 'Completed', 'Cancelled']), ('scheduled_date_start', '&lt;', current_date)]"


### PR DESCRIPTION
In #333 most of the stages were removed.

The following search filters were also moved, but do not use the removed stages for any logic.  These filters are used in base fieldservice module for the Teams dashboard and are also useful as filters in the search view.

This PR is to move them back into base fieldservice