### PR TITLE
[FIX] Team kanban dashboard

### DIFF
--- a/fieldservice/static/src/scss/team_dashboard.scss
+++ b/fieldservice/static/src/scss/team_dashboard.scss
@@ -1,5 +1,5 @@
 .o_kanban_view.o_kanban_ungrouped.o_kanban_dashboard.o_fsm_team_kanban {
-    &.o_kanban_record {
+    .o_kanban_record {
         width: 308px;
     }
 }


### PR DESCRIPTION
Team kanban card was too narrow because SCSS was incorrect

**Before**
![image](https://user-images.githubusercontent.com/25710115/66768350-5e7d3800-ee80-11e9-8260-0c66b804fdfa.png)

**After**
![image](https://user-images.githubusercontent.com/25710115/66768389-75bc2580-ee80-11e9-9198-ea9bb5179546.png)

