### PR TITLE
[IMP] fieldservice: Add Owned Locations to Partner

### DIFF
--- a/fieldservice/models/res_partner.py
+++ b/fieldservice/models/res_partner.py
@@ -11,3 +11,8 @@ class ResPartner(models.Model):
     fsm_person = fields.Boolean('Is a FS Worker')
     service_location_id = fields.Many2one('fsm.location',
                                           string='Primary Service Location')
+    owned_location_ids = fields.One2many('fsm.location',
+                                         'owner_id',
+                                         string='Owned Locations',
+                                         domain=[('fsm_parent_id', '=', False)]
+                                         )

--- a/fieldservice/models/res_partner.py
+++ b/fieldservice/models/res_partner.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018 - TODAY, Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
@@ -11,8 +11,35 @@ class ResPartner(models.Model):
     fsm_person = fields.Boolean('Is a FS Worker')
     service_location_id = fields.Many2one('fsm.location',
                                           string='Primary Service Location')
-    owned_location_ids = fields.One2many('fsm.location',
-                                         'owner_id',
-                                         string='Owned Locations',
-                                         domain=[('fsm_parent_id', '=', False)]
-                                         )
+    owned_location_ids = fields.One2many(
+        'fsm.location',
+        'owner_id',
+        string='Owned Locations',
+        domain=[('fsm_parent_id', '=', False)])
+    owned_location_count = fields.Integer(
+        compute='_compute_owned_location_count',
+        string="Owned Locations")
+
+    @api.multi
+    def _compute_owned_location_count(self):
+        for partner in self:
+            res = self.env['fsm.location'].search_count(
+                [('owner_id', '=', partner.id)])
+            partner.owned_location_count = res or 0
+
+    @api.multi
+    def action_open_owned_locations(self):
+        for partner in self:
+            owned_location_ids = self.env['fsm.location'].search(
+                [('owner_id', '=', partner.id)])
+            action = self.env.ref(
+                'fieldservice.action_fsm_location').read()[0]
+            action['context'] = {}
+            if len(owned_location_ids) > 1:
+                action['domain'] = [('id', 'in', owned_location_ids.ids)]
+            elif len(owned_location_ids) == 1:
+                action['views'] = [(
+                    self.env.ref(
+                        'fieldservice.fsm_location_form_view').id, 'form')]
+                action['res_id'] = owned_location_ids.ids[0]
+            return action

--- a/fieldservice/models/res_partner.py
+++ b/fieldservice/models/res_partner.py
@@ -25,7 +25,7 @@ class ResPartner(models.Model):
         for partner in self:
             res = self.env['fsm.location'].search_count(
                 [('owner_id', '=', partner.id)])
-            partner.owned_location_count = res or 0
+            partner.owned_location_count = res
 
     @api.multi
     def action_open_owned_locations(self):

--- a/fieldservice/views/res_partner.xml
+++ b/fieldservice/views/res_partner.xml
@@ -31,6 +31,24 @@
                         </group>
                         <group></group>
                     </group>
+                    <group name="owned_locations" string="Owned Locations">
+                        <field name="owned_location_ids"
+                               nolabel="1"
+                               context="{'default_owner_id': active_id}">
+                            <tree>
+                                <field name="ref"/>
+                                <field name="complete_name"/>
+                                <field name="category_id" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                                <field name="stage_id"/>
+                                <field name="street"/>
+                                <field name="street2"/>
+                                <field name="city"/>
+                                <field name="state_id"/>
+                                <field name="zip"/>
+                                <field name="territory_id"/>
+                            </tree>
+                        </field>
+                    </group>
                 </page>
             </notebook>
         </field>

--- a/fieldservice/views/res_partner.xml
+++ b/fieldservice/views/res_partner.xml
@@ -21,6 +21,17 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']/button[@name='toggle_active']" position="before">
+                <button class="oe_stat_button"
+                        type="object"
+                        attrs="{'invisible': [('owned_location_count', '=', 0)]}"
+                        name="action_open_owned_locations"
+                        icon="fa-map-marker"
+                        context="{'default_owner_id': active_id}"
+                        groups="fieldservice.group_fsm_user">
+                    <field string="Owned Locations" name="owned_location_count" widget="statinfo"/>
+                </button>
+            </xpath>
             <notebook position="inside">
                 <page string="Field Service">
                     <group>
@@ -30,24 +41,6 @@
                             <field name="service_location_id" context="{'default_contact_id': active_id}"/>
                         </group>
                         <group></group>
-                    </group>
-                    <group name="owned_locations" string="Owned Locations">
-                        <field name="owned_location_ids"
-                               nolabel="1"
-                               context="{'default_owner_id': active_id}">
-                            <tree>
-                                <field name="ref"/>
-                                <field name="complete_name"/>
-                                <field name="category_id" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                                <field name="stage_id"/>
-                                <field name="street"/>
-                                <field name="street2"/>
-                                <field name="city"/>
-                                <field name="state_id"/>
-                                <field name="zip"/>
-                                <field name="territory_id"/>
-                            </tree>
-                        </field>
                     </group>
                 </page>
             </notebook>


### PR DESCRIPTION
Add Owned Locations field to partner view in the Field Service page.
This gives visibility to show all parent locations owned by the partner.