### PR TITLE
[FIX] fieldservice: Copy Notes Error

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -267,7 +267,7 @@ class FSMOrder(models.Model):
 
     def copy_notes(self):
         self.description = ""
-        if self.type.name not in ['repair', 'maintenance']:
+        if self.type and self.type.name not in ['repair', 'maintenance']:
             for equipment_id in self.equipment_ids:
                 if equipment_id:
                     if equipment_id.notes is not False:


### PR DESCRIPTION
This PR adds a hotfix that checks to be sure the self.type before checking self.type.name