### PR TITLE
[FIX] fieldservice_account: required customer_id no longer breaks installation

### DIFF
--- a/fieldservice_account/models/fsm_location.py
+++ b/fieldservice_account/models/fsm_location.py
@@ -10,7 +10,7 @@ class FSMLocation(models.Model):
     analytic_account_id = fields.Many2one('account.analytic.account',
                                           string='Analytic Account')
     customer_id = fields.Many2one('res.partner', string='Billed Customer',
-                                  required=True, ondelete='restrict',
+                                  ondelete='restrict',
                                   auto_join=True,
                                   track_visibility='onchange')
 


### PR DESCRIPTION
Relevant for #367 
