### PR TITLE
[FIX] fieldservice_account: Error FSM Account

### DIFF
--- a/fieldservice_account/wizard/fsm_wizard.py
+++ b/fieldservice_account/wizard/fsm_wizard.py
@@ -12,6 +12,6 @@ class FSMWizard(models.TransientModel):
     _inherit = 'fsm.wizard'
 
     def _prepare_fsm_location(self, partner):
-        res = super(FSMWizard)._prepare_fsm_location(partner)
+        res = super()._prepare_fsm_location(partner)
         res['owner_id'] = partner.id
         return res


### PR DESCRIPTION
Remove 'FSMWizard' from super() to prevent:
AttributeError: 'super' object has no attribute '_prepare_fsm_location'
