### PR TITLE
[FIX] fieldservice_stock_account_analytic: Positional Arguments

### DIFF
--- a/fieldservice_stock_account_analytic/models/fsm_order.py
+++ b/fieldservice_stock_account_analytic/models/fsm_order.py
@@ -7,7 +7,8 @@ from odoo import models
 class FSMOrder(models.Model):
     _inherit = 'fsm.order'
 
-    def _prepare_inv_line_for_stock_request(self, invoice=False):
+    def _prepare_inv_line_for_stock_request(self, stock_request,
+                                            invoice=False):
         vals = super()._prepare_inv_line_for_stock_request(invoice)
         vals.update({
             'analytic_account_id': self.location_id.analytic_account_id.id,


### PR DESCRIPTION
In fieldservice_stock_account the method declaration looks like this:
def _prepare_inv_line_for_stock_request(self, stock_request, invoice=False):

fieldservice_stock_account_analytic overwrites that method declaration to only have 1-2 positional variables.

This PR adjusts fieldservice_stock_account_analytic to fix this error