### PR TITLE
[IMP] fieldservice_recurring: Add team_id field in Recurring FS Orders

### DIFF
--- a/fieldservice_recurring/models/fsm_recurring.py
+++ b/fieldservice_recurring/models/fsm_recurring.py
@@ -13,6 +13,9 @@ class FSMRecurringOrder(models.Model):
     _description = 'Recurring Field Service Order'
     _inherit = ['mail.thread', 'mail.activity.mixin']
 
+    def _default_team_id(self):
+        return self.env.ref('fieldservice.fsm_team_default')
+
     name = fields.Char(string='Name', required=True, index=True, copy=False,
                        default=lambda self: _('New'))
     state = fields.Selection([
@@ -48,6 +51,10 @@ class FSMRecurringOrder(models.Model):
         copy=False, readonly=True)
     fsm_order_count = fields.Integer(
         'Orders Count', compute='_compute_order_count')
+    team_id = fields.Many2one('fsm.team', string='Team',
+                              default=lambda self: self._default_team_id(),
+                              index=True, required=True,
+                              track_visibility='onchange')
 
     @api.multi
     @api.depends('fsm_order_ids')
@@ -142,6 +149,7 @@ class FSMRecurringOrder(models.Model):
         return {
             'fsm_recurring_id': self.id,
             'location_id': self.location_id.id,
+            'team_id': self.team_id.id,
             'scheduled_date_start': schedule_date,
             'request_early': str(earliest_date),
             'description': self.description,

--- a/fieldservice_recurring/tests/test_fsm_recurring.py
+++ b/fieldservice_recurring/tests/test_fsm_recurring.py
@@ -53,7 +53,7 @@ class FSMRecurringCase(TransactionCase):
             'schedule_days': 30,
             'fsm_frequency_ids': [(6, 0, rules.ids)]
         })
-        # Create Recurring Orddr link to this rule set
+        # Create Recurring Order link to this rule set
         recurring = self.Recurring.create({
             'fsm_frequency_set_id': fr_set.id,
             'location_id': self.test_location.id,
@@ -86,7 +86,7 @@ class FSMRecurringCase(TransactionCase):
 
     def test_cron_generate_orders_rule2(self):
         """Test recurring order with following rule,
-        - Work Order every 3 weeks, for
+        - Work Order every 3 weeks
         """
         rules = self.Frequency
         # Frequency Rule
@@ -100,7 +100,7 @@ class FSMRecurringCase(TransactionCase):
             'schedule_days': 100,
             'fsm_frequency_ids': [(6, 0, rules.ids)]
         })
-        # Create Recurring Orddr link to this rule set
+        # Create Recurring Order link to this rule set
         recurring = self.Recurring.create({
             'fsm_frequency_set_id': fr_set.id,
             'location_id': self.test_location.id,
@@ -135,7 +135,7 @@ class FSMRecurringCase(TransactionCase):
             'schedule_days': 365,
             'fsm_frequency_ids': [(6, 0, rules.ids)]
         })
-        # Create Recurring Orddr link to this rule set
+        # Create Recurring Order link to this rule set
         recurring = self.Recurring.create({
             'fsm_frequency_set_id': fr_set.id,
             'location_id': self.test_location.id,

--- a/fieldservice_recurring/views/fsm_recurring.xml
+++ b/fieldservice_recurring/views/fsm_recurring.xml
@@ -56,6 +56,8 @@
                         <group>
                             <field name="fsm_recurring_template_id"/>
                             <field name="location_id"/>
+                            <field name="team_id"
+                                   groups="fieldservice.group_fsm_team"/>
                             <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                         </group>
                     </group>


### PR DESCRIPTION
Add a `team_id` field in Recurring FS Orders.

Inspired by the `team_id` field in classic FS Orders. Also auto-fill the `team_id` field in the FS Orders created by a Recurring FS Order with the Recurring's `team_id`.

N-B : also edited small typing mystakes in the `fieldservice_recurring` test module.