### PR TITLE
[FIX] fieldservice

### DIFF
--- a/fieldservice/views/res_partner.xml
+++ b/fieldservice/views/res_partner.xml
@@ -20,6 +20,7 @@
         <field name="name">res.partner.fsm.form</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="groups_id" eval="[(4, ref('group_fsm_user'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']/button[@name='toggle_active']" position="before">
                 <button class="oe_stat_button"


### PR DESCRIPTION
Users without FSM access could not open contacts

This PR will allow a non-FSM user to be able to open the contact form without receiving error