### PR TITLE
[FIX] fieldservice: Multi Company Stages & Teams

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -20,8 +20,8 @@ class FSMOrder(models.Model):
         if stage_ids:
             return stage_ids[0]
         else:
-            raise ValidationError(_(
-                    "You must create an FSM Order Stage first."))
+            raise ValidationError(_("You must create an \
+                                    FSM Order Stage first."))
 
     def _default_team_id(self):
         team_ids = self.env['fsm.team'].\
@@ -30,8 +30,8 @@ class FSMOrder(models.Model):
         if team_ids:
             return team_ids[0]
         else:
-            raise ValidationError(_(
-                    "You must create an FSM Team first."))
+            raise ValidationError(_("You must create an \
+                                    FSM Team first."))
 
     @api.depends('date_start', 'date_end')
     def _compute_duration(self):

--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -13,10 +13,25 @@ class FSMOrder(models.Model):
     _inherit = ['mail.thread', 'mail.activity.mixin']
 
     def _default_stage_id(self):
-        return self.env.ref('fieldservice.fsm_stage_new')
+        stage_ids = self.env['fsm.stage'].\
+            search([('stage_type', '=', 'order'),
+                    ('company_id', '=', self.env.user.company_id.id)],
+                   order='sequence asc')
+        if stage_ids:
+            return stage_ids[0]
+        else:
+            raise ValidationError(_(
+                    "You must create an FSM Order Stage first."))
 
     def _default_team_id(self):
-        return self.env.ref('fieldservice.fsm_team_default')
+        team_ids = self.env['fsm.team'].\
+            search([('company_id', '=', self.env.user.company_id.id)],
+                   order='sequence asc')
+        if team_ids:
+            return team_ids[0]
+        else:
+            raise ValidationError(_(
+                    "You must create an FSM Team first."))
 
     @api.depends('date_start', 'date_end')
     def _compute_duration(self):
@@ -166,8 +181,9 @@ class FSMOrder(models.Model):
 
     @api.model
     def _read_group_stage_ids(self, stages, domain, order):
-        stage_ids = self.env['fsm.stage'].search([('stage_type',
-                                                   '=', 'order')])
+        stage_ids = self.env['fsm.stage'].\
+            search([('stage_type', '=', 'order'),
+                    ('company_id', '=', self.env.user.company_id.id)])
         return stage_ids
 
     @api.model


### PR DESCRIPTION
The following PR adjusts FSM to account for Teams and Stages in a multi-company environment by removing the reference to the xml id and instead using the sequence. 

NOTE: This PR solves the error from FSM Teams, it does not totally solve the errors from FSM Stage (to be implemented later)