### PR TITLE
[FIX] fieldservice_analytic_account: Analytic Account Company Dependant

### DIFF
--- a/fieldservice_account_analytic/models/fsm_location.py
+++ b/fieldservice_account_analytic/models/fsm_location.py
@@ -8,7 +8,8 @@ class FSMLocation(models.Model):
     _inherit = 'fsm.location'
 
     analytic_account_id = fields.Many2one('account.analytic.account',
-                                          string='Analytic Account')
+                                          string='Analytic Account',
+                                          company_dependent=True)
 
     customer_id = fields.Many2one(
         'res.partner', string='Billed Customer', required=True,


### PR DESCRIPTION
The following PR makes the analytic_account_id on FSM Locations company dependent so we can create invoices for different companies using the same locations.