### PR TITLE
[FIX] fieldservice_stock: Multiple back-orders if multiple moves

### DIFF
--- a/fieldservice_stock/models/stock_move.py
+++ b/fieldservice_stock/models/stock_move.py
@@ -18,9 +18,8 @@ class StockMove(models.Model):
             'current_stock_location_id': move_line.location_dest_id.id}
 
     def _action_done(self):
-        res = False
+        res = super()._action_done()
         for rec in self:
-            res = super(StockMove, rec)._action_done()
             if rec.picking_code == 'outgoing' and rec.state == 'done':
                 if rec.product_tmpl_id.create_fsm_equipment:
                     for line in rec.move_line_ids:


### PR DESCRIPTION
Steps to reproduce

* Create a sales or purchase order with multiple lines and confirm it
* Process the delivery order or receipt

Result

* 1 transfer per line (1 delivery/receipt + backorders)

Expected result

* 1 transfer