### PR TITLE
[IMP] Add Activites Setting + Template Notebook

### DIFF
--- a/fieldservice/models/res_config_settings.py
+++ b/fieldservice/models/res_config_settings.py
@@ -27,6 +27,8 @@ class ResConfigSettings(models.TransientModel):
     # Modules
     module_fieldservice_account = fields.Boolean(
         string='Invoice your FSM orders')
+    module_fieldservice_activity = fields.Boolean(
+        string='Manage FSM Activities')
     module_fieldservice_agreement = fields.Boolean(
         string='Manage Agreements')
     module_fieldservice_crm = fields.Boolean(

--- a/fieldservice/views/fsm_template.xml
+++ b/fieldservice/views/fsm_template.xml
@@ -40,9 +40,11 @@
                                    groups="fieldservice.group_fsm_team"/>
                         </group>
                     </group>
-                    <group string="Instructions">
-                        <field name="instructions" nolabel="1" widget="html"/>
-                    </group>
+                    <notebook>
+                        <page string="Instructions" name="instructions_page">
+                            <field name="instructions" nolabel="1" widget="html"/>
+                        </page>
+                    </notebook>
                 </sheet>
             </form>
         </field>

--- a/fieldservice/views/res_config_settings.xml
+++ b/fieldservice/views/res_config_settings.xml
@@ -287,6 +287,17 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-xs-12 col-md-6 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="module_fieldservice_activity"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="manage_order_activities" string="Manage Order Activities"/>
+                                <div class="text-muted">
+                                    Manage activities
+                                </div>
+                            </div>
+                        </div>
                     </div>
                     <h2>Mapping Tools</h2>
                     <div class="row mt16 o_settings_container" id="mapping">


### PR DESCRIPTION
The following PR adds 'Manage FSM Activites' to the Fieldservice Settings. It also moves the Instrustions on FSM Templates to a notebook for better consistency with FSM Orders and if in case we want to further expand on FSM Templates. #459 