### PR TITLE
[IMP] fieldservice: Minor changes

### DIFF
--- a/fieldservice/models/fsm_location.py
+++ b/fieldservice/models/fsm_location.py
@@ -61,7 +61,7 @@ class FSMLocation(models.Model):
                                group_expand='_read_group_stage_ids',
                                default=lambda self: self._default_stage_id())
 
-    @api.depends('partner_id.name', 'fsm_parent_id.complete_name')
+    @api.depends('partner_id.name', 'fsm_parent_id.complete_name', 'ref')
     def _compute_complete_name(self):
         for loc in self:
             if loc.fsm_parent_id:
@@ -253,21 +253,21 @@ class FSMLocation(models.Model):
         either be a in a list or in a form view, if there is only one
         contact to show.
         '''
-        for location in self:
+        for contact in self:
             action = self.env.ref('contacts.action_contacts').\
                 read()[0]
-            contacts = self.get_action_views(1, 0, location)
+            contacts = self.get_action_views(1, 0, contact)
             action['context'] = self.env.context.copy()
+            action['context'].update({'group_by': ''})
             action['context'].update({'default_service_location_id': self.id})
-            if len(contacts) == 1:
-                action['views'] = [(self.env.ref('base.view_partner_form').id,
+            if len(contacts) == 0 or len(contacts) > 1:
+                action['domain'] = [('id', 'in', contacts.ids)]
+            elif contacts:
+                action['views'] = [(self.env.
+                                    ref('base.' +
+                                        'view_partner_form').id,
                                     'form')]
                 action['res_id'] = contacts.id
-                action['context'].update({'active_id': contacts.id})
-            else:
-                action['domain'] = [('id', 'in', contacts.ids)]
-                action['context'].update({'active_ids': contacts.ids})
-                action['context'].update({'active_id': ''})
             return action
 
     @api.multi
@@ -288,6 +288,7 @@ class FSMLocation(models.Model):
                 read()[0]
             equipment = self.get_action_views(0, 1, location)
             action['context'] = self.env.context.copy()
+            action['context'].update({'group_by': ''})
             action['context'].update({'default_location_id': self.id})
             if len(equipment) == 0 or len(equipment) > 1:
                 action['domain'] = [('id', 'in', equipment.ids)]
@@ -316,6 +317,7 @@ class FSMLocation(models.Model):
             action = self.env.ref('fieldservice.action_fsm_location').read()[0]
             sublocation = self.get_action_views(0, 0, location)
             action['context'] = self.env.context.copy()
+            action['context'].update({'group_by': ''})
             action['context'].update({'default_fsm_parent_id': self.id})
             if len(sublocation) > 1 or len(sublocation) == 0:
                 action['domain'] = [('id', 'in', sublocation.ids)]

--- a/fieldservice/models/fsm_location.py
+++ b/fieldservice/models/fsm_location.py
@@ -253,10 +253,10 @@ class FSMLocation(models.Model):
         either be a in a list or in a form view, if there is only one
         contact to show.
         '''
-        for contact in self:
+        for location in self:
             action = self.env.ref('contacts.action_contacts').\
                 read()[0]
-            contacts = self.get_action_views(1, 0, contact)
+            contacts = self.get_action_views(1, 0, location)
             action['context'] = self.env.context.copy()
             action['context'].update({'group_by': ''})
             action['context'].update({'default_service_location_id': self.id})

--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -4,7 +4,7 @@
 from datetime import datetime, timedelta
 from odoo import api, fields, models, _
 from . import fsm_stage
-from odoo.exceptions import ValidationError
+from odoo.exceptions import ValidationError, UserError
 
 
 class FSMOrder(models.Model):
@@ -225,8 +225,16 @@ class FSMOrder(models.Model):
                     from_string(vals.get('request_early')) + timedelta(hours=8)
         return super(FSMOrder, self).create(vals)
 
+    is_button = fields.Boolean(default=False)
+
     @api.multi
     def write(self, vals):
+        if vals.get('stage_id', False) and vals.get('is_button', False):
+            vals['is_button'] = False
+        else:
+            stage_id = self.env['fsm.stage'].browse(vals.get('stage_id'))
+            if stage_id == self.env.ref('fieldservice.fsm_stage_completed'):
+                raise UserError(_('Cannot move to completed from Kanban'))
         self._calc_scheduled_dates(vals)
         res = super(FSMOrder, self).write(vals)
         return res
@@ -283,7 +291,7 @@ class FSMOrder(models.Model):
 
     def action_complete(self):
         return self.write({'stage_id': self.env.ref(
-            'fieldservice.fsm_stage_completed').id})
+            'fieldservice.fsm_stage_completed').id, 'is_button': True})
 
     def action_cancel(self):
         return self.write({'stage_id': self.env.ref(
@@ -306,37 +314,41 @@ class FSMOrder(models.Model):
             self.scheduled_date_end = str(date_to_with_delta)
 
     def copy_notes(self):
+        old_desc = self.description
         self.description = ""
+        self.location_directions = ""
         if self.type and self.type.name not in ['repair', 'maintenance']:
             for equipment_id in self.equipment_ids:
                 if equipment_id:
-                    if equipment_id.notes is not False:
-                        if self.description is not False:
+                    if equipment_id.notes:
+                        if self.description:
                             self.description = (self.description +
                                                 equipment_id.notes + '\n ')
                         else:
                             self.description = (equipment_id.notes + '\n ')
         else:
             if self.equipment_id:
-                if self.equipment_id.notes is not False:
-                    if self.description is not False:
+                if self.equipment_id.notes:
+                    if self.description:
                         self.description = (self.description +
                                             self.equipment_id.notes + '\n ')
                     else:
                         self.description = (self.equipment_id.notes + '\n ')
         if self.location_id:
             s = self.location_id.direction
-            if s is not False and s != '<p><br></p>':
+            if s and s != '<p><br></p>':
                 s = s.replace('<p>', '')
                 s = s.replace('<br>', '')
                 s = s.replace('</p>', '\n')
-                if self.location_directions is not False:
-                    self.location_directions = (self.location_directions +
-                                                '\n' + s + '\n')
-                else:
-                    self.location_directions = (s + '\n ')
+                self.location_directions = (s + '\n ')
         if self.template_id:
-            self.todo = self.template_id.instructions
+            if self.template_id.instructions:
+                self.todo += self.template_id.instructions
+        if self.description:
+            self.description += '\n' + old_desc
+        else:
+            self.description = old_desc
+
 
     @api.onchange('location_id')
     def onchange_location_id(self):
@@ -357,5 +369,14 @@ class FSMOrder(models.Model):
             self.category_ids = self.template_id.category_ids
             self.scheduled_duration = self.template_id.hours
             self.copy_notes()
-            self.type = self.template_id.type_id
+            if not self.type:
+                self.type = self.template_id.type_id
             self.team_id = self.template_id.team_id
+
+
+class FSMTeam(models.Model):
+    _inherit = 'fsm.team'
+
+    order_ids = fields.One2many(
+        'fsm.order', 'team_id', string='Orders',
+        domain=[('stage_id.is_closed', '=', False)])

--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -342,8 +342,7 @@ class FSMOrder(models.Model):
                 s = s.replace('</p>', '\n')
                 self.location_directions = (s + '\n ')
         if self.template_id:
-            if self.template_id.instructions:
-                self.todo += self.template_id.instructions
+            self.todo = self.template_id.instructions
         if self.description:
             self.description += '\n' + old_desc
         else:

--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -369,6 +369,5 @@ class FSMOrder(models.Model):
             self.category_ids = self.template_id.category_ids
             self.scheduled_duration = self.template_id.hours
             self.copy_notes()
-            if not self.type:
-                self.type = self.template_id.type_id
+            self.type = self.template_id.type_id
             self.team_id = self.template_id.team_id

--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -372,11 +372,3 @@ class FSMOrder(models.Model):
             if not self.type:
                 self.type = self.template_id.type_id
             self.team_id = self.template_id.team_id
-
-
-class FSMTeam(models.Model):
-    _inherit = 'fsm.team'
-
-    order_ids = fields.One2many(
-        'fsm.order', 'team_id', string='Orders',
-        domain=[('stage_id.is_closed', '=', False)])

--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -348,7 +348,6 @@ class FSMOrder(models.Model):
         else:
             self.description = old_desc
 
-
     @api.onchange('location_id')
     def onchange_location_id(self):
         if self.location_id:

--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -14,6 +14,7 @@
                             type="object"
                             groups="fieldservice.group_fsm_dispatcher"
                             attrs="{'invisible': [('stage_id', 'in', (%(fieldservice.fsm_stage_completed)d, %(fieldservice.fsm_stage_cancelled)d))]}" />
+                    <field name="is_button" invisible="1"/>
                     <button id="action_cancel"
                             name="action_cancel" string="Cancel Order"
                             type="object"


### PR DESCRIPTION
When a user changes the Internal Reference on a FSM Location, the complete_name field is not updated. Since it is part of the complete_name field, I believe it should update when changed.

Ticket #1499

When a user changes the Template we only set Type if it is False. We also want to append to the existing description instead of overwriting it when copyting notes.

Ticket #1679

When a user pulls up a tree view, enables a group_by filter, selects a record, then selects a smartbutton, if that group_by field is not on the corresponding smart_button object then a KeyError will be thrown. This is resolved by removing the group_by key from the context dictionary after it is copied.

Ticket #1336

On FSO's when a user sets the Location, the directions are then copied into the Location Directions on the FSO properly. However, whenever the call_notes() is called, it duplicates the Location Directions. The only thing that should be in this field are the directions from the assigned FSM Location.

Ticket #1854

On FSO's users were moving the Kanban cards and not triggering the logic that is stored in the buttons that move the stage on the form view. We prevent this by adding a boolean field that is returned True only when the button is clicked. If it is not through the button then we will throw a UserError and move the Kanban card back to its original stage

Ticket #1481