### PR TITLE
[FIX] fieldservice_location_builder: Timezone Error + Dependency Error

### DIFF
--- a/fieldservice_location_builder/__manifest__.py
+++ b/fieldservice_location_builder/__manifest__.py
@@ -9,7 +9,7 @@
     'author': 'Open Source Integrators, Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/field-service',
     'depends': [
-        'fieldservice'
+        'fieldservice_account_analytic'
     ],
     'data': [
         'wizard/fsm_location_builder_wizard.xml',

--- a/fieldservice_location_builder/wizard/fsm_location_builder_wizard.py
+++ b/fieldservice_location_builder/wizard/fsm_location_builder_wizard.py
@@ -22,33 +22,39 @@ class FSMLocationBuilderWizard(models.TransientModel):
                 spacer = " "
             for lev_id in range(self.level_ids[num].start_number,
                                 self.level_ids[num].end_number + 1):
-                tags = self.level_ids[num].tag_ids.ids
-                vals = {'name': self.level_ids[num].
-                        name + spacer + str(lev_id),
-                        'owner_id': location.owner_id.id,
-                        'customer_id': location.customer_id.id,
-                        'fsm_parent_id': parent.id,
-                        'street': location.street,
-                        'street2':  self.level_ids[num].
-                        name + spacer + str(lev_id),
-                        'city': location.city,
-                        'zip': location.zip,
-                        }
-                if tags:
-                    vals.update({
-                        'category_id': [(6, 0, tags)]
-                    })
-
-                if location.state_id:
-                    vals.update([('state_id', location.state_id.id)])
-                if location.country_id:
-                    vals.update([('country_id', location.country_id.id)])
-                if location.territory_id:
-                    vals.update([('territory_id', location.territory_id.id)])
-                if location.tz:
-                    vals.update([('tz', location.tz.id)])
-
-                new_location = self.env['fsm.location'].create(vals)
+                vals = self.prepare_fsm_location_values(location, parent, spacer, lev_id, num)
+                new_location = self.env['fsm.location'].create(vals)                
                 if num < levels:
                     build_location(new_location, num + 1)
         build_location(location, 0)
+
+    def prepare_fsm_location_values(self, location, parent,
+                                    spacer, lev_id, num):
+        tags = self.level_ids[num].tag_ids.ids
+        vals = {'name': self.level_ids[num].
+                name + spacer + str(lev_id),
+                'owner_id': location.owner_id.id,
+                'customer_id': location.customer_id.id,
+                'fsm_parent_id': parent.id,
+                'street': location.street,
+                'street2':  self.level_ids[num].
+                name + spacer + str(lev_id),
+                'city': location.city,
+                'zip': location.zip,
+                }
+        if tags:
+            vals.update({
+                'category_id': [(6, 0, tags)]
+            })
+
+        if location.state_id:
+            vals.update([('state_id', location.state_id.id)])
+        if location.country_id:
+            vals.update([('country_id', location.country_id.id)])
+        if location.territory_id:
+            vals.update([('territory_id', location.territory_id.id)])
+        if location.tz:
+            vals.update([('tz', location.tz)])
+        return vals
+
+        

--- a/fieldservice_location_builder/wizard/fsm_location_builder_wizard.py
+++ b/fieldservice_location_builder/wizard/fsm_location_builder_wizard.py
@@ -22,8 +22,9 @@ class FSMLocationBuilderWizard(models.TransientModel):
                 spacer = " "
             for lev_id in range(self.level_ids[num].start_number,
                                 self.level_ids[num].end_number + 1):
-                vals = self.prepare_fsm_location_values(location, parent, spacer, lev_id, num)
-                new_location = self.env['fsm.location'].create(vals)                
+                vals = self.prepare_fsm_location_values(
+                    location, parent, spacer, lev_id, num)
+                new_location = self.env['fsm.location'].create(vals)
                 if num < levels:
                     build_location(new_location, num + 1)
         build_location(location, 0)
@@ -56,5 +57,3 @@ class FSMLocationBuilderWizard(models.TransientModel):
         if location.tz:
             vals.update([('tz', location.tz)])
         return vals
-
-        


### PR DESCRIPTION
The 'tz' field on an fsm_location is a selection field. When building a hierarchy on a record with a tz an error is thrown the is fixed with this PR. Another error discovered was customer_id has been moved to fieldservice_account_analytic. The 2 solutions are to have this module depend on fieldservice_account_analytic, or split the customer_id field into a separate module called fieldservice_account_analytic_location_builder similar to how we made fieldservice_stock_location_builder.

UPDATE 02/28: I split the vals on the wizard into a separate method. This makes it easier for us to inherit this method and extend its functionality