### PR TITLE
[FIX] fieldservice: False team from template

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -358,4 +358,5 @@ class FSMOrder(models.Model):
             self.scheduled_duration = self.template_id.hours
             self.copy_notes()
             self.type = self.template_id.type_id
-            self.team_id = self.template_id.team_id
+            if self.template_id.team_id:
+                self.team_id = self.template_id.team_id


### PR DESCRIPTION
Fixes bug introduced with #441 

If teams are not enabled, the template's team will be False.  When a user sets a template on the order, the order team is set to False when team is a required field