### PR TITLE
[IMP] fieldservice_isp_account: Default Set Project and Task

### DIFF
--- a/fieldservice_isp_account/__manifest__.py
+++ b/fieldservice_isp_account/__manifest__.py
@@ -11,6 +11,7 @@
     'website': 'https://github.com/OCA/field-service',
     'depends': [
         'fieldservice_account_analytic',
+        'fieldservice_project',
         'hr_timesheet',
     ],
     'data': [

--- a/fieldservice_isp_account/views/fsm_order.xml
+++ b/fieldservice_isp_account/views/fsm_order.xml
@@ -50,7 +50,7 @@
                     <field name="contractor_total" readonly="1"/>
                 </group>
                 <group string="Employee Timesheets">
-                    <field name="employee_timesheet_ids" nolabel="1">
+                    <field name="employee_timesheet_ids" nolabel="1" context="{'default_project_id': project_id, 'default_task_id': project_task_id}">
                         <tree editable="bottom"
                                 string="Timesheet Activities"
                                 default_order="date">
@@ -63,6 +63,8 @@
                             <field name="name"/>
                             <field name="unit_amount" string="Duration"
                                     widget="float_time"/>
+                            <field name="project_id" invisible="1"/>
+                            <field name="task_id" invisible="1"/>
                         </tree>
                     </field>
                 </group>


### PR DESCRIPTION
When timesheets are entered they do not show up in the timesheets app because the time entered is not associated with a task or project. This resolves the issue however the user may not know they need to set a Project and Task. I made this module dependent on fsm_project which I believe is necessary however I did not make project_id and project_task_id required. 

Ticket #1234 Low: Timesheet (FSO Entries) – Employee Timesheet Entries on FSO’s don’t show in Timesheet App