### PR TITLE
[IMP] fieldservice_project: Default Project From Team on Order

### DIFF
--- a/fieldservice_project/__manifest__.py
+++ b/fieldservice_project/__manifest__.py
@@ -19,6 +19,7 @@
         'views/fsm_location_views.xml',
         'views/fsm_order_views.xml',
         'security/ir.model.access.csv',
+        'views/fsm_team.xml'
     ],
     'installable': True,
 }

--- a/fieldservice_project/models/__init__.py
+++ b/fieldservice_project/models/__init__.py
@@ -4,3 +4,4 @@ from . import fsm_location
 from . import fsm_order
 from . import project
 from . import project_task
+from . import fsm_team

--- a/fieldservice_project/models/fsm_order.py
+++ b/fieldservice_project/models/fsm_order.py
@@ -29,3 +29,8 @@ class FSMOrder(models.Model):
                                          'fsm_order_form').id, 'form')]
         action['res_id'] = order.id
         return action
+
+    @api.onchange('team_id')
+    def onchange_team_id(self):
+        if self.team_id:
+            self.project_id = self.team_id.project_id

--- a/fieldservice_project/models/fsm_team.py
+++ b/fieldservice_project/models/fsm_team.py
@@ -1,0 +1,10 @@
+# Copyright (C) 2020, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class FSMTeam(models.Model):
+    _inherit = 'fsm.team'
+
+    project_id = fields.Many2one('project.project', string="Project")

--- a/fieldservice_project/views/fsm_team.xml
+++ b/fieldservice_project/views/fsm_team.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="view_fsm_team_project_form" model="ir.ui.view">
+        <field name="name">view.fsm.team.project.form</field>
+        <field name="model">fsm.team</field>
+        <field name="inherit_id" ref="fieldservice.view_team_form"/>
+        <field name="arch" type="xml">
+            <field name="sequence" position="after">
+                <field name="project_id"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Paired with #542, automatically default the project on an FSO to whatever is assigned to that team. Similar to the way projects are set on Helpdesk Tickets via Helpdesk Teams.