### PR TITLE
[IMP] fieldservice_stock: Request Workflow Adjustment

### DIFF
--- a/fieldservice_stock/models/stock_request.py
+++ b/fieldservice_stock/models/stock_request.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from datetime import datetime, timedelta
-from odoo import api, fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 
 
 class StockRequest(models.Model):
@@ -42,28 +42,26 @@ class StockRequest(models.Model):
             fsm_order = self.env['fsm.order'].browse(vals['fsm_order_id'])
             fsm_order.request_stage = 'draft'
             vals['warehouse_id'] = fsm_order.warehouse_id.id
-            val_date = vals['expected_date']
-            if not isinstance(vals['expected_date'], str):
-                val_date = datetime.strftime(vals['expected_date'],
-                                             '%Y-%m-%d %H:%M:%S')
-            val_date = datetime.strptime(val_date, '%Y-%m-%d %H:%M:%S')
             picking_type_id = self.env['stock.picking.type'].search(
                 [('code', '=', 'stock_request_order'),
                  ('warehouse_id', '=', vals['warehouse_id'])],
                 limit=1)
-            date_window_after = val_date - timedelta(hours=1)
             order = self.env['stock.request.order'].search([
                 ('fsm_order_id', '=', vals['fsm_order_id']),
                 ('warehouse_id', '=', vals['warehouse_id']),
                 ('picking_type_id', '=', picking_type_id.id),
                 ('direction', '=', vals['direction']),
-                ('expected_date', '>', date_window_after),
-                ('state', '=', 'draft')
-            ])
-            if order:
-                vals['expected_date'] = order.expected_date
-                vals['order_id'] = order.id
-            else:
+                ('state', '=', 'draft')], order="id asc")
+
+            # User created a new SRO Manually
+            if len(order) > 1:
+                raise UserError(_('There is already a Stock Request Order \
+                                  with the same Field Service Order and \
+                                  Warehouse that is in Draft state. Please \
+                                  add this Stock Request there. \
+                                  (%s)') % order[0].name)
+            # Made from an FSO for the first time, create the SRO here
+            elif not order and vals.get('fsm_order_id'):
                 values = self.prepare_order_values(vals)
                 values.update({
                     'picking_type_id': picking_type_id.id,
@@ -71,6 +69,10 @@ class StockRequest(models.Model):
                     })
                 vals['order_id'] = self.env['stock.request.order'].\
                     create(values).id
+            # There is an SRO made from FSO, assign here
+            elif len(order) == 1 and vals.get('fsm_order_id'):
+                vals['expected_date'] = order.expected_date
+                vals['order_id'] = order.id
         return super().create(vals)
 
     def _prepare_procurement_values(self, group_id=False):

--- a/fieldservice_stock/models/stock_request_order.py
+++ b/fieldservice_stock/models/stock_request_order.py
@@ -11,7 +11,7 @@ class StockRequestOrder(models.Model):
         'fsm.order', string="FSM Order", ondelete='cascade',
         index=True, copy=False)
 
-    @api.onchange('direction', 'fsm_order_id')
+    @api.onchange('warehouse_id', 'direction', 'fsm_order_id')
     def _onchange_location_id(self):
         super()._onchange_location_id()
         if self.fsm_order_id:


### PR DESCRIPTION
The following PR makes changes to the fieldservice_stock module to fix a bug that was taking SR's from new SRO's and appending them to existing ones. While this is somewhat the desired behavior, we do not want it automated, and should instead output an error message letting the user know that an existing SRO with matching FSO and Warehouse and is in draft stage exists, and the user should make their SR there. I added a few things to make sure to make sure we do not interfere with the default SR Workflow when it is not associated with an FSO.

Edit: In order to maintain consistency with PR: OCA/stock-logistics-warehouse#874 I have changed the header for the onchange methods in fieldservice_stock