### PR TITLE
[IMP] fieldservice_change_management (Add default search context)

### DIFF
--- a/fieldservice_change_management/views/fsm_location.xml
+++ b/fieldservice_change_management/views/fsm_location.xml
@@ -9,7 +9,8 @@
                         class="oe_stat_button"
                         icon="fa-pencil-square-o"
                         groups="fieldservice_change_management.change_log_group_readonly"
-                        context="{'default_location_id': active_id}">
+                        context="{'search_default_location_id': active_id,
+                                  'default_location_id': active_id}">
                     <field name="change_log_count"
                            widget="statinfo"
                            string="Change Logs"/>


### PR DESCRIPTION
This was missing the default search context so if you clicked the change logs smart button on a location with zero change logs it would show all the logs which was confusing. This adds the default search context to reduce confusion.