### PR TITLE
[12.0][IMP] fieldservice_recurring

### DIFF
--- a/fieldservice_recurring/models/fsm_recurring.py
+++ b/fieldservice_recurring/models/fsm_recurring.py
@@ -55,6 +55,8 @@ class FSMRecurringOrder(models.Model):
                               default=lambda self: self._default_team_id(),
                               index=True, required=True,
                               track_visibility='onchange')
+    person_id = fields.Many2one('fsm.person', string='Assigned To',
+                                index=True, track_visibility='onchange')
 
     @api.multi
     @api.depends('fsm_order_ids')
@@ -158,13 +160,16 @@ class FSMRecurringOrder(models.Model):
             'category_ids': [(
                 6, False,
                 self.fsm_order_template_id.category_ids.ids)],
-            # 'company_id': self.company_id.id,
+            'company_id': self.company_id.id,
+            'person_id': self.person_id.id,
         }
 
     def _create_order(self, date):
         self.ensure_one()
         vals = self._prepare_order_values(date)
-        return self.env['fsm.order'].create(vals)
+        order = self.env['fsm.order'].create(vals)
+        order._onchange_template_id()
+        return order
 
     @api.multi
     def _generate_orders(self):

--- a/fieldservice_recurring/views/fsm_recurring.xml
+++ b/fieldservice_recurring/views/fsm_recurring.xml
@@ -10,6 +10,7 @@
                 <field name="name"/>
                 <field name="location_id"/>
                 <field name="fsm_order_template_id" groups="fieldservice.group_fsm_template"/>
+                <field name="person_id"/>
                 <field name="end_date"/>
                 <field name="state"/>
             </tree>
@@ -47,6 +48,7 @@
                     </div>
                     <group>
                         <group>
+                            <field name="fsm_recurring_template_id"/>
                             <field name="fsm_order_template_id" groups="fieldservice.group_fsm_template"/>
                             <field name="fsm_frequency_set_id"/>
                             <field name="start_date"/>
@@ -54,10 +56,10 @@
                             <field name="max_orders"/>
                         </group>
                         <group>
-                            <field name="fsm_recurring_template_id"/>
                             <field name="location_id"/>
                             <field name="team_id"
                                    groups="fieldservice.group_fsm_team"/>
+                            <field name="person_id"/>
                             <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                         </group>
                     </group>


### PR DESCRIPTION
- Added a person_id field to recurring orders that will populate person_id for the FSM orders created
- Trigger FSM order onchange method for template in order to populate additional fields for the FSM order when created