### PR TITLE
[12.0] Add field internal_type in fsm.order.type

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -193,6 +193,9 @@ class FSMOrder(models.Model):
     equipment_ids = fields.Many2many('fsm.equipment', string='Equipments')
     type = fields.Many2one('fsm.order.type', string="Type")
 
+    internal_type = fields.Selection(string='Internal Type',
+                                     related='type.internal_type')
+
     @api.model
     def _read_group_stage_ids(self, stages, domain, order):
         search_domain = [('stage_type', '=', 'order')]

--- a/fieldservice/models/fsm_order_type.py
+++ b/fieldservice/models/fsm_order_type.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2019 Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 
@@ -8,3 +9,9 @@ class FSMOrderType(models.Model):
     _description = 'Field Service Order Type'
 
     name = fields.Char(string='Name')
+
+    internal_type = fields.Selection(
+        string="Internal Type",
+        selection=[('fsm', 'FSM')],
+        default='fsm',
+    )

--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -50,8 +50,9 @@
                             <field name="team_id"
                                    groups="fieldservice.group_fsm_team"/>
                             <field name="person_id"/>
+                            <field name="internal_type" invisible="1"/>
                             <field name="equipment_id"
-                                   attrs="{'invisible':[('type', 'not in',['repair', 'maintenance'])]}"
+                                   attrs="{'invisible':[('internal_type', 'not in',['repair', 'maintenance'])]}"
                                    groups="fieldservice.group_fsm_equipment"
                                    options="{'no_create': True}"
                                    domain="[('current_location_id','=',location_id)]"/>
@@ -119,9 +120,9 @@
                         <page string="Equipments"
                               groups="fieldservice.group_fsm_equipment"
                               name="equipements_page"
-                              attrs="{'invisible': [('type', 'in', ['repair', 'maintenance'])]}">
+                              attrs="{'invisible': [('internal_type', 'in', ['repair', 'maintenance'])]}">
                             <field name="equipment_ids"
-                                   attrs="{'required': [('type', 'not in', ['repair', 'maintenance'])]}"
+                                   attrs="{'required': [('internal_type', 'not in', ['repair', 'maintenance'])]}"
                                    options="{'no_create': True}"
                                    domain="[('current_location_id','=',location_id)]">
                                 <tree>

--- a/fieldservice/views/fsm_order_type.xml
+++ b/fieldservice/views/fsm_order_type.xml
@@ -8,6 +8,7 @@
         <field name="arch" type="xml">
             <tree string="Order Types">
                 <field name="name"/>
+                <field name="internal_type"/>
             </tree>
         </field>
     </record>
@@ -21,6 +22,9 @@
                 <sheet>
                     <label for="name" class="oe_edit_only"/>
                     <h1><field name="name"/></h1>
+                    <group>
+                        <field name="internal_type"/>
+                    </group>
                 </sheet>
             </form>
         </field>


### PR DESCRIPTION
I will use this field to fix the fieldservice_maintenance and fieldservice_repair modules that were compromised when the Type field changed to fsm.order.type.

I believe that this way we can make the integration with the maintenance and repair modules even more dynamic.