### PR TITLE
[IMP] fieldservice_stage_server_action: Remove dependency

### DIFF
--- a/fieldservice_stage_server_action/__manifest__.py
+++ b/fieldservice_stage_server_action/__manifest__.py
@@ -9,7 +9,6 @@
     'website': 'https://github.com/ursais/osi-addons',
     'depends': [
         'fieldservice',
-        'fieldservice_substatus',
         'base_automation'
     ],
     'data': [

--- a/fieldservice_stage_server_action/readme/CONTRIBUTORS.rst
+++ b/fieldservice_stage_server_action/readme/CONTRIBUTORS.rst
@@ -3,3 +3,5 @@
   * Wolfgang Hall <whall@opensourceintegrators.com>
   * Maxime Chambreuil <mchambreuil@opensourceintegrators.com>
   * Steve Campbell <scampbell@opensourceintegrators.com>
+
+* Brian McMaster <brian@mcmpest.com>

--- a/fieldservice_stage_server_action/views/fsm_stage.xml
+++ b/fieldservice_stage_server_action/views/fsm_stage.xml
@@ -6,7 +6,7 @@
         <field name="model">fsm.stage</field>
         <field name="inherit_id" ref="fieldservice.fsm_stage_form_view"/>
         <field name="arch" type="xml">
-            <field name="sub_stage_id" position="after">
+            <field name="sequence" position="after">
                 <field name="action_id"/>
             </field>
         </field>


### PR DESCRIPTION
This module depended on fieldservice_substatus only so it could inherit an inherited view.  This removes that dependency and directly inherits the base view for FSM Stage