### PR TITLE
[IMP] fieldservice: Order complete button permission

### DIFF
--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -12,7 +12,7 @@
                             name="action_complete" string="Complete"
                             class="oe_highlight"
                             type="object"
-                            groups="fieldservice.group_fsm_dispatcher"
+                            groups="fieldservice.group_fsm_user"
                             attrs="{'invisible': [('stage_id', 'in', (%(fieldservice.fsm_stage_completed)d, %(fieldservice.fsm_stage_cancelled)d))]}" />
                     <field name="is_button" invisible="1"/>
                     <button id="action_cancel"


### PR DESCRIPTION
closes #588 - FSM User group cannot view Complete button on FSM orders