### PR TITLE
[FIX] fieldservice_distribution (Smart Button Count)

### DIFF
--- a/fieldservice_distribution/models/fsm_location.py
+++ b/fieldservice_distribution/models/fsm_location.py
@@ -19,7 +19,7 @@ class FSMLocation(models.Model):
     def _compute_distrib_sublocation_ids(self):
         for location in self:
             location.distrib_count = self.env['fsm.location'].search_count(
-                [('fsm_parent_id', 'child_of', location.id), (
+                [('dist_parent_id', '=', location.id), (
                     'id', '!=', location.id), (
                     'is_a_distribution', '=', True)])
 
@@ -33,8 +33,11 @@ class FSMLocation(models.Model):
         """
         for location in self:
             action = self.env.ref('fieldservice.action_fsm_location').read()[0]
-            sublocation = self.get_action_views(0, 0, location)
-            sublocation.filtered(lambda r: r.is_a_distribution)
+            sublocation = self.env["fsm.location"].search(
+                [('dist_parent_id', '=', location.id),
+                 ('id', '!=', location.id),
+                 ('is_a_distribution', '=', True)]
+            )
             if len(sublocation) == 1:
                 action['views'] = [(self.env.
                                     ref('fieldservice.' +

--- a/fieldservice_distribution/views/fsm_location.xml
+++ b/fieldservice_distribution/views/fsm_location.xml
@@ -13,7 +13,7 @@
                         class="oe_stat_button"
                         icon="fa-sitemap"
                         attrs="{'invisible': [('is_a_distribution', '!=', True)]}"
-                        context="{'default_fsm_parent_id': active_id,
+                        context="{'default_fsm_parent_id': fsm_parent_id,
                                   'default_dist_parent_id': active_id,
                                   'default_is_a_distribution': True}">
                     <field name="distrib_count"


### PR DESCRIPTION
This fixes the functionality of the 'Distributed To' smart button. Before this fix, the smart button was looking for locations that had it's fsm_parent_id set which is incorrect because we want to link locations that have their parent distribution set to the record. 

With this fix, the 'Distributed To' smart button now counts all locations that have the 'Parent Distribution' set to the current record, and it then opens the views with those proper filter. It also shows only direct relationships as distribution instead of all children since we only care about direct child unlike the sub location smart button.