### PR TITLE
[12.0][IMP] fieldservice : Use commercial_partner_id when convert a fsm_location

### DIFF
--- a/fieldservice/wizard/fsm_wizard.py
+++ b/fieldservice/wizard/fsm_wizard.py
@@ -31,7 +31,7 @@ class FSMWizard(models.TransientModel):
     def _prepare_fsm_location(self, partner):
         return {
             'partner_id': partner.id,
-            'owner_id': partner.id,
+            'owner_id': partner.commercial_partner_id.id
         }
 
     def action_convert_location(self, partner):


### PR DESCRIPTION
Because it makes more sense when a child contact of company is converted to keep the owning to the parent company and it makes no difference when there is no parent_id relation in the partner.