### PR TITLE
Added a Geo-Locate button to the FSM Location form

### DIFF
--- a/fieldservice/models/fsm_location.py
+++ b/fieldservice/models/fsm_location.py
@@ -335,6 +335,10 @@ class FSMLocation(models.Model):
             return action
 
     @api.multi
+    def geo_localize(self):
+        return self.partner_id.geo_localize()
+
+    @api.multi
     def _compute_equipment_ids(self):
         for loc in self:
             equipment = self.comp_count(0, 1, loc)

--- a/fieldservice/views/fsm_location.xml
+++ b/fieldservice/views/fsm_location.xml
@@ -131,6 +131,26 @@
                                 <group id="others-right"></group>
                             </group>
                         </page>
+                        <page string="Geo Location" name="geo_location">
+                            <group id="get_locate" colspan="2" col="2">
+                                <separator string="Geolocation" colspan="2"/>
+                                <button
+                                    string="Geolocate"
+                                    name="geo_localize"
+                                    colspan="2"
+                                    icon="fa-check"
+                                    type="object"/>
+                                <div>
+                                    <span class="oe_inline"> ( On  </span>
+                                    <field name="date_localization" nolabel="1" class="oe_inline"/>
+                                    <span> : Lat : </span>
+                                    <field name="partner_latitude" nolabel="1" class="oe_inline"/>
+                                    <span> ;  Long:  </span>
+                                    <field name="partner_longitude" nolabel="1" class="oe_inline"/>
+                                    <span>) </span>
+                                </div>
+                            </group>
+                        </page>
                     </notebook>
                 </sheet>
                 <div class="oe_chatter">


### PR DESCRIPTION
On the FSM Location, have a tab for "Geo Location" data, similar the "Partner Assignation" tab, including the Geolocate button. Users expect to have the Geo Location features on the FSM location form, as they do on the Partner Form.