### PR TITLE
[12.0][IMP] Added check for existing fsm.equipment before creating

### DIFF
--- a/fieldservice_stock/models/stock_move.py
+++ b/fieldservice_stock/models/stock_move.py
@@ -22,11 +22,16 @@ class StockMove(models.Model):
     def _action_done(self):
         res = super()._action_done()
         for rec in self:
-            if (rec.state == 'done'
-                    and rec.picking_type_id.create_fsm_equipment
-                    and rec.product_tmpl_id.create_fsm_equipment):
-                for line in rec.move_line_ids:
-                    vals = self.prepare_equipment_values(line)
-                    line.lot_id.fsm_equipment_id = \
-                        rec.env['fsm.equipment'].create(vals)
+            if rec.picking_code == 'outgoing' and rec.state == 'done':
+                if rec.product_tmpl_id.create_fsm_equipment:
+                    for line in rec.move_line_ids:
+                        vals = self.prepare_equipment_values(line)
+                        equipment_id = self.env['fsm.equipment'].search(
+                            [('name', '=', line.lot_id.name)]
+                        )
+                        if equipment_id:
+                            line.lot_id.fsm_equipment_id = equipment_id.id
+                        else:
+                            line.lot_id.fsm_equipment_id = \
+                                rec.env['fsm.equipment'].create(vals)
         return res

--- a/fieldservice_stock/models/stock_move.py
+++ b/fieldservice_stock/models/stock_move.py
@@ -22,16 +22,17 @@ class StockMove(models.Model):
     def _action_done(self):
         res = super()._action_done()
         for rec in self:
-            if rec.picking_code == 'outgoing' and rec.state == 'done':
-                if rec.product_tmpl_id.create_fsm_equipment:
-                    for line in rec.move_line_ids:
-                        vals = self.prepare_equipment_values(line)
-                        equipment_id = self.env['fsm.equipment'].search(
-                            [('name', '=', line.lot_id.name)]
-                        )
-                        if equipment_id:
-                            line.lot_id.fsm_equipment_id = equipment_id.id
-                        else:
-                            line.lot_id.fsm_equipment_id = \
-                                rec.env['fsm.equipment'].create(vals)
+            if (rec.state == 'done'
+                    and rec.picking_type_id.create_fsm_equipment
+                    and rec.product_tmpl_id.create_fsm_equipment):
+                for line in rec.move_line_ids:
+                    vals = self.prepare_equipment_values(line)
+                    equipment_id = self.env['fsm.equipment'].search(
+                        [('name', '=', line.lot_id.name)]
+                    )
+                    if equipment_id:
+                        line.lot_id.fsm_equipment_id = equipment_id.id
+                    else:
+                        line.lot_id.fsm_equipment_id = \
+                            rec.env['fsm.equipment'].create(vals)
         return res


### PR DESCRIPTION
Added a check to verify if a related fsm.equipment object exists before attempting to create one for assigning to the line.lot_id.fsm_equipment_id field.

This mitigates an issue we encountered during outgoing stock moves involving equipment which had previously been deployed to an fsm.location and then recovered.