### PR TITLE
[FIX][12.0] fsm.order unlink method only evaluates first record

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -260,12 +260,10 @@ class FSMOrder(models.Model):
 
     @api.multi
     def unlink(self):
-        for order in self:
-            if order.can_unlink():
-                return super(FSMOrder, order).unlink()
-            else:
-                raise ValidationError(_(
-                    "You cannot delete this order."))
+        if all(order.can_unlink() for order in self):
+            return super(FSMOrder, self).unlink()
+        else:
+            raise ValidationError(_("You cannot delete this order."))
 
     def _calc_scheduled_dates(self, vals):
         """Calculate scheduled dates and duration"""


### PR DESCRIPTION
This doesn't cause issues when deleting a single order, but when selecting multiple orders (e.g. from the list view), it will only evaluate the first one. 

WIth this change, all records are evaluated and deleted, unless the ValidationError is raised.

Just looking at the code, the 13.0 version seems to have the same issue, though I haven't tested it.