### PR TITLE
[FIX][12.0] fieldservice_status (Field Requirement)

### DIFF
--- a/fieldservice_substatus/views/fsm_stage.xml
+++ b/fieldservice_substatus/views/fsm_stage.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="fieldservice.fsm_stage_form_view"/>
         <field name="arch" type="xml">
             <field name="sequence" position="after">
-                <field name="sub_stage_id" required="1" attrs="{'invisible':[('stage_type', '!=', 'order')]}"/>
+                <field name="sub_stage_id" attrs="{'invisible':[('stage_type', '!=', 'order')], 'required': [('stage_type', '=', 'order')]}"/>
                 <field name="sub_stage_ids" widget="many2many_tags" attrs="{'invisible':[('stage_type', '!=', 'order')]}"/>
             </field>
         </field>


### PR DESCRIPTION
There was an issue where the sub status field was hidden on the form for anything other than FSM Orders however it was also required. This PR just updates the attributes to only require the field when the stage is an FSM order.