### PR TITLE
[FIX][12.0] fix dependencies of fieldservice_stock_account_analytic

### DIFF
--- a/fieldservice_stock_account_analytic/__manifest__.py
+++ b/fieldservice_stock_account_analytic/__manifest__.py
@@ -11,6 +11,7 @@
               "Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/field-service',
     'depends': [
+        'fieldservice_account_analytic',
         'fieldservice_stock_account',
         'stock_request_analytic',
     ],


### PR DESCRIPTION
In its models, fieldservice_stock_account_analytic makes use of the field "analytic_account_id" of "fsm.location". The field is added to that model in the fieldservice_account_analytic module. 

https://github.com/OCA/field-service/blob/17e018c37b9b0f5ff5655620ab8f5bea848d427b/fieldservice_account_analytic/models/fsm_location.py#L7-L12

The current dependency tree doesn't require fieldservice_account_analytic to be installed, resulting in errors.