### PR TITLE
[14.0][FIX] fieldservice_timeline

### DIFF
--- a/fieldservice_timeline/models/fsm_person.py
+++ b/fieldservice_timeline/models/fsm_person.py
@@ -6,4 +6,4 @@ from odoo import models
 
 class FSMPerson(models.Model):
     _name = "fsm.person"
-    _inherit = ["fsm.person", "mail.activity.mixin", "mail.thread.blacklist"]
+    _inherit = ["fsm.person", "mail.activity.mixin"]


### PR DESCRIPTION
Removed an unused table inherit.

TypeError: Cannot create a consistent method resolution
order (MRO) for bases BaseModel, mail.thread, mail.activity.mixin, mail.thread.blacklist, base