### PR TITLE
[12.0][IMP] fieldservice_maintenance: add scheduled_date_start and scheduled_duration from maintenance request

### DIFF
--- a/fieldservice_maintenance/models/maintenance_request.py
+++ b/fieldservice_maintenance/models/maintenance_request.py
@@ -34,6 +34,8 @@ class MaintenanceRequest(models.Model):
                  'location_id': fsm_equipment.current_location_id.id,
                  'request_id': request.id,
                  'description': request.description,
+                 'scheduled_date_start': request.schedule_date,
+                 'scheduled_duration': request.duration
                  })
             request.fsm_order_id = fsm_order_id
         return request


### PR DESCRIPTION
Adds the scheduled_date_start and scheduled_duration to the FSM Order created via the Maintenance Order.