### PR TITLE
[12.0][FIX] Fieldservice_Stock: Fix inventory_location_id default

### DIFF
--- a/fieldservice_stock/models/fsm_location.py
+++ b/fieldservice_stock/models/fsm_location.py
@@ -16,5 +16,6 @@ class FSMLocation(models.Model):
     @api.onchange('fsm_parent_id')
     def _onchange_fsm_parent_id(self):
         super(FSMLocation, self)._onchange_fsm_parent_id()
-        self.inventory_location_id = \
-            self.fsm_parent_id.inventory_location_id.id
+        if self.fsm_parent_id:
+            self.inventory_location_id = \
+                self.fsm_parent_id.inventory_location_id.id


### PR DESCRIPTION
The onchange method was causing the default inventory_location_id to never actually show in the interface during location creation, as the field was set back to empty (given that fsm_parent_id was itself also empty).

This way the onchange functionality is preserved when needed, but the default value is also applied correctly