### PR TITLE
[12.0][FIX] fieldservice (Create Worker Error)

### DIFF
--- a/fieldservice/views/fsm_person.xml
+++ b/fieldservice/views/fsm_person.xml
@@ -51,7 +51,7 @@
                     <h1><field name="name" required="True"/></h1>
                     <group>
                         <group>
-                            <field name="partner_id" groups="base.group_no_one" readonly="1" />
+                            <field name="partner_id" groups="base.group_no_one" readonly="1"  required="False" />
                             <field name="category_ids"
                                    widget="many2many_tags"
                                    options="{'color_field': 'color'}"/>


### PR DESCRIPTION
Fixes partner_id field required error when creating a worker. This implements the same fix that was merged for the same error on locations (#754 ).

Related to Issues:
#755 
#683 