### PR TITLE
[14.0][FIX] fieldservice

### DIFF
--- a/fieldservice/__manifest__.py
+++ b/fieldservice/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Field Service",
     "summary": "Manage Field Service Locations, Workers and Orders",
-    "version": "14.0.1.0.2",
+    "version": "14.0.1.0.3",
     "license": "AGPL-3",
     "category": "Field Service",
     "author": "Open Source Integrators, Odoo Community Association (OCA)",

--- a/fieldservice/__manifest__.py
+++ b/fieldservice/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Field Service",
     "summary": "Manage Field Service Locations, Workers and Orders",
-    "version": "14.0.1.0.3",
+    "version": "14.0.1.0.2",
     "license": "AGPL-3",
     "category": "Field Service",
     "author": "Open Source Integrators, Odoo Community Association (OCA)",

--- a/fieldservice/models/fsm_location.py
+++ b/fieldservice/models/fsm_location.py
@@ -175,10 +175,12 @@ class FSMLocation(models.Model):
         self.territory_manager_id = self.territory_id.person_id or False
         self.branch_id = self.territory_id.branch_id or False
         if self.env.user.company_id.auto_populate_persons_on_location:
+            person_vals_list = []
             for person in self.territory_id.person_ids:
-                self.env["fsm.location.person"].create(
-                    {"location_id": self.id, "person_id": person.id, "sequence": 10}
+                person_vals_list.append(
+                    (0, 0, {"person_id": person.id, "sequence": 10})
                 )
+            self.person_ids = self.territory_id and person_vals_list or False
 
     @api.onchange("branch_id")
     def _onchange_branch_id(self):


### PR DESCRIPTION
**Error:-**
Create Service Location and fill Territory based on onchange below issue is raised.

The operation cannot be completed:
- Create/update: a mandatory field is not set.
- Delete: another model requires the record being deleted. If possible, archive it instead.

Model: Field Service Location Person Info (fsm.location.person), Field: Location (location_id)

**Reproduce steps:-**

1) Enable Auto-fill the workers on the location from Settings << Field Service << Locations

![1](https://user-images.githubusercontent.com/20418904/120596183-0d5cf600-c461-11eb-9386-c3cacd094e76.png)

2) Configure Field Service Workers under Territories (Settings << Users & Companies)

![2](https://user-images.githubusercontent.com/20418904/120596383-51e89180-c461-11eb-810f-655552c221b5.png)

3) Create Service Locations Field Service << Master Data << Locations

![3](https://user-images.githubusercontent.com/20418904/120596777-c4f20800-c461-11eb-908d-7eae4b6941fb.png)
