### PR TITLE
[FIX][12.0]Fix gantt view error with date_range

### DIFF
--- a/fieldservice/static/src/js/fsm_gantt.js
+++ b/fieldservice/static/src/js/fsm_gantt.js
@@ -76,9 +76,7 @@ odoo.define('fieldservice.fsm_gantt', function (require) {
             // Make the user filter clear
             if (this.modelClass.modelName == 'fsm.order'){
                 self.$el.find(
-                    '#user_filer .o_searchview_extended_prop_field').val('');
-                self.$el.find(
-                    '#user_filer .o_searchview_extended_prop_field').change();
+                    '#user_filer .o_searchview_extended_prop_value input').val('');
                 self.$el.find(
                     '#user_filer .o_searchview_extended_prop_field').val(
                     'category_id');

--- a/fieldservice/static/src/js/fsm_gantt_person_filter.js
+++ b/fieldservice/static/src/js/fsm_gantt_person_filter.js
@@ -212,9 +212,7 @@ odoo.define('fsm_gantt.person_filter', function (require) {
             if (clear) {
                 self.user_domains = false;
                 self.$el.find(
-                    '#user_filer .o_searchview_extended_prop_field').val('');
-                self.$el.find(
-                    '#user_filer .o_searchview_extended_prop_field').change();
+                    '#user_filer .o_searchview_extended_prop_value input').val('');
                 self.$el.find(
                     '#user_filer .o_searchview_extended_prop_field').val(
                     'category_id');

--- a/fieldservice/static/src/xml/fsm_gantt_person_filter.xml
+++ b/fieldservice/static/src/xml/fsm_gantt_person_filter.xml
@@ -16,7 +16,6 @@
     <t t-extend="SearchView.extended_search.proposition">
         <t t-jquery=".o_searchview_extended_prop_field" t-operation="prepend">
             <t t-if="widget.__parentedParent and widget.__parentedParent.user_filter">
-                <option></option>
                 <t t-foreach="widget.attrs.fields" t-as="field">
                     <option t-att="{'selected': field.name == 'category_id' ? 'selected' : null}"
                             t-att-value="field.name">


### PR DESCRIPTION
Fixed client error on fsm.order's Gantt View when date_range is also installed.

The issue was that the <select> element used as a filter could be empty. The onchange triggered when it was empty would cause the error. 
See also: #802

I considered proposing a fix on date_range, but this seems to be the only view with such an issue. These changes are also more consistent with the rest of the interface, where the <select> in question cannot be empty.