### PR TITLE
[13.0][FIX] fieldservice - in order to use request_early from vals, check request_early is there

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -261,25 +261,22 @@ class FSMOrder(models.Model):
         )
         self._calc_scheduled_dates(vals)
         if not vals.get("request_late"):
-            if vals.get("priority") == "0":
-                if vals.get("request_early"):
-                    vals["request_late"] = fields.Datetime.from_string(
-                        vals.get("request_early")
-                    ) + timedelta(days=3)
-                else:
-                    vals["request_late"] = datetime.now() + timedelta(days=3)
-            elif vals.get("priority") == "1":
+            priority = vals.get("priority")
+            days_number = 0
+            if priority == "0":
+                days_number = 3
+            elif priority == "1":
+                days_number = 2
+            elif priority == "2":
+                days_number = 1
+            elif priority == "3":
+                days_number = 8
+            if vals.get("request_early"):
                 vals["request_late"] = fields.Datetime.from_string(
                     vals.get("request_early")
-                ) + timedelta(days=2)
-            elif vals.get("priority") == "2":
-                vals["request_late"] = fields.Datetime.from_string(
-                    vals.get("request_early")
-                ) + timedelta(days=1)
-            elif vals.get("priority") == "3":
-                vals["request_late"] = fields.Datetime.from_string(
-                    vals.get("request_early")
-                ) + timedelta(hours=8)
+                ) + timedelta(days=days_number)
+            else:
+                vals["request_late"] = datetime.now() + timedelta(days=days_number)
         return super(FSMOrder, self).create(vals)
 
     is_button = fields.Boolean(default=False)


### PR DESCRIPTION
The check for vals.get("request_early") is only done when priority is 0 but should be done for all the cases.
Otherwise when you add timedelta you'll get : TypeError: unsupported operand type(s) for +: 'NoneType' and 'datetime.timedelta'