### PR TITLE
[13.0][FIX] fieldservice_stock - reference partner_id instead of customer_id in test case

### DIFF
--- a/fieldservice_stock/tests/common.py
+++ b/fieldservice_stock/tests/common.py
@@ -25,7 +25,7 @@ class TestFSMStockCommon(SavepointCase):
             {
                 "name": "FSM Location 1",
                 "owner_id": cls.partner_1.id,
-                "customer_id": cls.partner_1.id,
+                "partner_id": cls.partner_1.id,
                 "inventory_location_id": cls.stock_cust_loc,
             }
         )


### PR DESCRIPTION
Issue: #812 