### PR TITLE
[12.0][FIX]Fixed _compute_request_late methods

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -97,21 +97,19 @@ class FSMOrder(models.Model):
         help="Company related to this order")
 
     def _compute_request_late(self, vals):
-        if vals.get('priority') == '0':
-            if vals.get('request_early'):
-                vals['request_late'] = fields.Datetime.\
-                    from_string(vals.get('request_early')) + timedelta(days=3)
-            else:
-                vals['request_late'] = datetime.now() + timedelta(days=3)
-        elif vals.get('priority') == '1':
-            vals['request_late'] = fields.Datetime.\
-                from_string(vals.get('request_early')) + timedelta(days=2)
-        elif vals.get('priority') == '2':
-            vals['request_late'] = fields.Datetime.\
-                from_string(vals.get('request_early')) + timedelta(days=1)
-        elif vals.get('priority') == '3':
-            vals['request_late'] = fields.Datetime.\
-                from_string(vals.get('request_early')) + timedelta(hours=8)
+        if vals.get("request_early", False):
+            early = fields.Datetime.from_string(vals.get("request_early"))
+        else:
+            early = datetime.now()
+
+        if vals.get("priority") == "0":
+            vals["request_late"] = early + timedelta(days=3)
+        elif vals.get("priority") == "1":
+            vals["request_late"] = early + timedelta(days=2)
+        elif vals.get("priority") == "2":
+            vals["request_late"] = early + timedelta(days=1)
+        elif vals.get("priority") == "3":
+            vals["request_late"] = early + timedelta(hours=8)
         return vals
 
     request_late = fields.Datetime(string='Latest Request Date')
@@ -219,22 +217,7 @@ class FSMOrder(models.Model):
                          'request_early': str(req_date)})
         self._calc_scheduled_dates(vals)
         if not vals.get('request_late'):
-            if vals.get('priority') == '0':
-                if vals.get('request_early'):
-                    vals['request_late'] = \
-                        fields.Datetime.from_string(vals.get('request_early'))\
-                        + timedelta(days=3)
-                else:
-                    vals['request_late'] = datetime.now() + timedelta(days=3)
-            elif vals.get('priority') == '1':
-                vals['request_late'] = fields.Datetime.\
-                    from_string(vals.get('request_early')) + timedelta(days=2)
-            elif vals.get('priority') == '2':
-                vals['request_late'] = fields.Datetime.\
-                    from_string(vals.get('request_early')) + timedelta(days=1)
-            elif vals.get('priority') == '3':
-                vals['request_late'] = fields.Datetime.\
-                    from_string(vals.get('request_early')) + timedelta(hours=8)
+            vals = self._compute_request_late(vals)
         return super(FSMOrder, self).create(vals)
 
     is_button = fields.Boolean(default=False)

--- a/fieldservice_recurring/models/fsm_order.py
+++ b/fieldservice_recurring/models/fsm_order.py
@@ -12,15 +12,19 @@ class FSMOrder(models.Model):
     fsm_recurring_id = fields.Many2one(
         'fsm.recurring', 'Recurring Order', readonly=True)
 
-    def _compute_request_late(self):
-        for rec in self:
-            if not rec.fsm_recurring_id:
-                return super(FSMOrder, self)._compute_request_late()
-            else:
-                days_late = rec.fsm_recurring_id.fsm_frequency_set_id.\
-                    buffer_late
-                rec.request_late = rec.scheduled_date_start + timedelta(
-                    days=days_late)
+    def _compute_request_late(self, vals):
+        if not vals.get("fsm_recurring_id", False):
+            return super(FSMOrder, self)._compute_request_late(vals)
+        elif vals.get("scheduled_date_start", False):
+            days_late = (
+                self.env["fsm.recurring"]
+                .browse(vals["fsm_recurring_id"])
+                .fsm_frequency_set_id.buffer_late
+            )
+            vals["request_late"] = vals["scheduled_date_start"] + timedelta(
+                days=days_late
+            )
+        return vals
 
     @api.multi
     def action_view_fsm_recurring(self):


### PR DESCRIPTION
- There's a `_compute_request_late` method in the fieldservice/models/fsm_order.py model, but it's not used. In the `create` the same code is duplicated. This PR avoids duplication and also allows additional modules to easily access and modify the method itself, since it's not embedded in the `create` method anymore.

- The `_compute_request_late` method doesn't always check that `request_early` exists. Now it's checked at the start See also #808 for a similar fix on version 13.0

- Related fix in fieldservice_recurring/models/fsm_order.py : this module extends the method, but the signature doesn't match that of the original method, causing errors. The way the method was structured also didn't reflect how the original method works, so it has been updated.

