### PR TITLE
[12.0][IMP] fieldservice: Add settings for automatic calculation of request_late field of fsm.order

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -103,13 +103,21 @@ class FSMOrder(models.Model):
             early = datetime.now()
 
         if vals.get("priority") == "0":
-            vals["request_late"] = early + timedelta(days=3)
+            vals["request_late"] = early + timedelta(
+                hours=self.env.user.company_id.order_prio0_request_late
+            )
         elif vals.get("priority") == "1":
-            vals["request_late"] = early + timedelta(days=2)
+            vals["request_late"] = early + timedelta(
+                hours=self.env.user.company_id.order_prio1_request_late
+            )
         elif vals.get("priority") == "2":
-            vals["request_late"] = early + timedelta(days=1)
+            vals["request_late"] = early + timedelta(
+                hours=self.env.user.company_id.order_prio2_request_late
+            )
         elif vals.get("priority") == "3":
-            vals["request_late"] = early + timedelta(hours=8)
+            vals["request_late"] = early + timedelta(
+                hours=self.env.user.company_id.order_prio3_request_late
+            )
         return vals
 
     request_late = fields.Datetime(string='Latest Request Date')

--- a/fieldservice/models/res_company.py
+++ b/fieldservice/models/res_company.py
@@ -14,3 +14,20 @@ class ResCompany(models.Model):
     search_on_complete_name = fields.Boolean(
         string='Search Location By Hierarchy'
     )
+
+    order_prio0_request_late = fields.Float(
+        string="Hours of Buffer for Lowest Priority FS Orders",
+        default=72,
+    )
+    order_prio1_request_late = fields.Float(
+        string="Hours of Buffer for Low Priority FS Orders",
+        default=48,
+    )
+    order_prio2_request_late = fields.Float(
+        string="Hours of Buffer for Medium Priority FS Orders",
+        default=24,
+    )
+    order_prio3_request_late = fields.Float(
+        string="Hours of Buffer for High Priority FS Orders",
+        default=8
+    )

--- a/fieldservice/models/res_config_settings.py
+++ b/fieldservice/models/res_config_settings.py
@@ -93,6 +93,26 @@ class ResConfigSettings(models.TransientModel):
         string='Search Location By Hierarchy',
         related='company_id.search_on_complete_name',
         readonly=False)
+    order_prio0_request_late = fields.Float(
+        string="Hours of Buffer for Lowest Priority FS Orders",
+        related='company_id.order_prio0_request_late',
+        readonly=False,
+    )
+    order_prio1_request_late = fields.Float(
+        string="Hours of Buffer for Low Priority FS Orders",
+        related='company_id.order_prio1_request_late',
+        readonly=False,
+    )
+    order_prio2_request_late = fields.Float(
+        string="Hours of Buffer for Medium Priority FS Orders",
+        related='company_id.order_prio2_request_late',
+        readonly=False,
+    )
+    order_prio3_request_late = fields.Float(
+        string="Hours of Buffer for High Priority FS Orders",
+        related='company_id.order_prio3_request_late',
+        readonly=False,
+    )
 
     # Dependencies
     @api.onchange('group_fsm_equipment')

--- a/fieldservice/views/res_config_settings.xml
+++ b/fieldservice/views/res_config_settings.xml
@@ -161,6 +161,40 @@
                     </div>
                     <h2>Orders</h2>
                     <div class="row mt16 o_settings_container" id="orders">
+                        <div class="col-xs-12 col-md-6 o_setting_box">
+                            <div class="o_setting_left_pane"/>
+                            <div class="o_setting_right_pane">
+                                <span class="o_form_label">
+                                    Priority-based rules
+                                </span>
+                                <div class="text-muted">Automatically calculate the "Latest Request Date" based on an order's priority</div>
+                                <div class="content-group" modifiers="{}">
+                                    <div class="row mt16" modifiers="{}">
+                                        <label string="Priority 0" for="order_prio0_request_late" class="col-lg-3 o_light_label"/>
+                                        <field name="order_prio0_request_late"/><span class="ml-2">hours</span>
+                                    </div>
+                                    <div class="row mt16" modifiers="{}">
+                                        <label string="Priority 1" for="order_prio1_request_late" class="col-lg-3 o_light_label"/>
+                                        <field name="order_prio1_request_late"/><span class="ml-2">hours</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-xs-12 col-md-6 o_setting_box">
+                            <div class="o_setting_left_pane"/>
+                            <div class="o_setting_right_pane">
+                                <div class="content-group" modifiers="{}">
+                                    <div class="row mt16" modifiers="{}">
+                                        <label string="Priority 2" for="order_prio2_request_late" class="col-lg-3 o_light_label"/>
+                                        <field name="order_prio2_request_late"/><span class="ml-2">hours</span>
+                                    </div>
+                                    <div class="row mt16" modifiers="{}">
+                                        <label string="Priority 3" for="order_prio3_request_late" class="col-lg-3 o_light_label"/>
+                                        <field name="order_prio3_request_late"/><span class="ml-2">hours</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                         <div class="col-xs-12 col-md-6 o_setting_box"
                              attrs="{'invisible': [('group_fsm_equipment', '=', False)]}">
                             <div class="o_setting_left_pane">


### PR DESCRIPTION
This PR builds on #815 and will not work without it (it already containts all the changes from that PR as well).

Currently the Latest Request Date `request_late` field of a fsm.order is automatically calculated based on hardcoded values of 3 days, 2 days, 1 day or 8 hours depending on the priority of the order. This pr adds 4 settings that allow the user to customize these timedeltas.