### PR TITLE
[14.0][FIX] fieldservice: Purchase setting sets non-existant group

### DIFF
--- a/fieldservice/models/res_config_settings.py
+++ b/fieldservice/models/res_config_settings.py
@@ -108,4 +108,4 @@ class ResConfigSettings(models.TransientModel):
     @api.onchange("module_fieldservice_purchase")
     def _onchange_module_fieldservice_purchase(self):
         if self.module_fieldservice_purchase:
-            self.group_manage_vendor_price = True
+            self.group_product_pricelist = True

--- a/fieldservice/tests/__init__.py
+++ b/fieldservice/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_fsm_person
 from . import test_fsm_team
 from . import test_fsm_order
 from . import test_fsm_order_template_onchange
+from . import test_res_config_settings

--- a/fieldservice/tests/test_res_config_settings.py
+++ b/fieldservice/tests/test_res_config_settings.py
@@ -1,0 +1,12 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestSettings(TransactionCase):
+
+    def test_module_purchase(self):
+
+        config = self.env["res.config.settings"].create({})
+        config._onchange_module_fieldservice_purchase()
+        config.flush()
+        config.execute()
+        self.assertEqual(self.env.user.has_group('product.group_product_pricelist'), True)


### PR DESCRIPTION
Enabling the Purchase setting installs the purchase module and
tries to enable group_manage_vendor_price. However, this
group name was changed several years ago. It should set
group_product_pricelist instead.