### PR TITLE
[14.0][IMP] fieldservice_sale: remove required attr in product view

### DIFF
--- a/fieldservice_sale/views/product_template.xml
+++ b/fieldservice_sale/views/product_template.xml
@@ -8,7 +8,7 @@
                 <field name="field_service_tracking" widget="radio" />
                 <field
                     name="fsm_order_template_id"
-                    attrs="{'invisible': [('field_service_tracking', '=', 'no')], 'required': [('field_service_tracking', '!=', 'no')]}"
+                    attrs="{'invisible': [('field_service_tracking', '=', 'no')]}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Create a blank fsm from a SO is a valid use case.
And it make more sense when used with fsm_recurring_sale

Implement rfc #735