### PR TITLE
[14.0][FIX] Improved _track_subtype method

### DIFF
--- a/fieldservice_substatus/models/fsm_order.py
+++ b/fieldservice_substatus/models/fsm_order.py
@@ -27,5 +27,5 @@ class FSMOrder(models.Model):
     def _track_subtype(self, init_values):
         self.ensure_one()
         if "sub_stage_id" in init_values:
-            return "fieldservice_substatus.fso_substatus_changed"
+            return self.env.ref("fieldservice_substatus.fso_substatus_changed")
         return super()._track_subtype(init_values)


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/serpentcs/odoo/14.0/odoo/http.py", line 640, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/serpentcs/odoo/14.0/odoo/http.py", line 316, in _handle_exception
    raise exception.with_traceback(None) from new_cause
AttributeError: 'str' object has no attribute 'exists'