### PR TITLE
[13.0][FIX] fieldservice_account : Fixed OU script issue

### DIFF
--- a/fieldservice_account/README.rst
+++ b/fieldservice_account/README.rst
@@ -72,6 +72,7 @@ Contributors
 * Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
 * Brian McMaster <brian@mcmpest.com>
+* Chankya Soni <csoni@opensourceintegrators.com>
 
 Other credits
 ~~~~~~~~~~~~~

--- a/fieldservice_account/migrations/13.0.1.0.0/pre-migration.py
+++ b/fieldservice_account/migrations/13.0.1.0.0/pre-migration.py
@@ -3,19 +3,11 @@
 
 from openupgradelib import openupgrade
 
-_model_renames = [
-    ("account.invoice", "account.move"),
-    ("account.invoice.line", "account.move.line"),
-]
-
 _table_renames = [
-    ("account.invoice", "account.move"),
-    ("account.invoice.line", "account.move.line"),
     ("fsm_order_account_invoice_rel", "fsm_order_account_move_rel"),
 ]
 
 
 @openupgrade.migrate()
 def migrate(env, version):
-    openupgrade.rename_models(env.cr, _model_renames)
     openupgrade.rename_tables(env.cr, _table_renames)

--- a/fieldservice_account/migrations/13.0.2.0.0/post-migration.py
+++ b/fieldservice_account/migrations/13.0.2.0.0/post-migration.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Akretion <raphael.reverdy@akretion.com>
+# Copyright (C) 2018, Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openupgradelib import openupgrade
@@ -10,7 +11,7 @@ def _field_type_change(env):
         env["account.move.line"],
         "account_move_line",
         "fsm_order_ids",
-        openupgrade.get_legacy_name("fsm_order_id"),
+        "fsm_order_id",
     )
 
 

--- a/fieldservice_account/migrations/13.0.2.0.0/pre-migration.py
+++ b/fieldservice_account/migrations/13.0.2.0.0/pre-migration.py
@@ -1,13 +1,30 @@
+# Copyright (C) 2018, Open Source Integrators
 # Copyright 2020 Akretion <raphael.reverdy@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openupgradelib import openupgrade
 
-column_renames = {
-    "account_move_line": [("fsm_order_id", None)],
-}
+
+def update_fsm_order_in_aml(cr):
+    """ Update fsm_order_id in account.move.line to use in post migration """
+    openupgrade.logged_query(
+        cr,
+        """
+            ALTER TABLE account_move_line ADD COLUMN fsm_order_id INTEGER
+        """,
+    )
+    openupgrade.logged_query(
+        cr,
+        """update account_move_line
+        set
+            fsm_order_id=ail.fsm_order_id
+        from
+            account_invoice_line ail
+        where
+            ail.id=account_move_line.old_invoice_line_id""",
+    )
 
 
 @openupgrade.migrate()
 def migrate(env, version):
-    openupgrade.rename_columns(env.cr, column_renames)
+    update_fsm_order_in_aml(env.cr)


### PR DESCRIPTION
a) "account.invoice", "account.move" > No need to add this as in core odoo account module this would be done already.
b)  "account_move_line": [("fsm_order_id", None)]  > Was giving error. This won't work as fsm_order_id is available in account_invoice_line not in account_move_line. That's why modified pre-migration script.