### PR TITLE
[12.0][FIX]Added float_time widget to fsm.order form view

### DIFF
--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -79,7 +79,7 @@
                                 </group>
                                 <group id="schedule" string="Schedule Details">
                                     <field name="scheduled_date_start"/>
-                                    <field name="scheduled_duration"/>
+                                    <field name="scheduled_duration" widget="float_time"/>
                                     <field name="scheduled_date_end"
                                            readonly="1"/>
                                 </group>
@@ -112,7 +112,7 @@
                                 <group id="execution-left">
                                     <field name="date_start"/>
                                     <field name="date_end"/>
-                                    <field name="duration" readonly="1"/>
+                                    <field name="duration" widget="float_time" readonly="1"/>
                                 </group>
                                 <group id="execution-right"/>
                             </group>


### PR DESCRIPTION
Currently the two duration fields of the FSM.Order model are displayed as floats.
This PR adds the float_time widget to make the fields more human-readable.