### PR TITLE
[FIX] by default fsm_category, fsm_tag, fsm_team, fsm_stage are share…

### DIFF
--- a/fieldservice/models/fsm_category.py
+++ b/fieldservice/models/fsm_category.py
@@ -16,9 +16,8 @@ class FSMCategory(models.Model):
     company_id = fields.Many2one(
         "res.company",
         string="Company",
-        required=True,
+        required=False,
         index=True,
-        default=lambda self: self.env.user.company_id,
         help="Company related to this category",
     )
 

--- a/fieldservice/models/fsm_stage.py
+++ b/fieldservice/models/fsm_stage.py
@@ -54,7 +54,6 @@ class FSMStage(models.Model):
     company_id = fields.Many2one(
         "res.company",
         string="Company",
-        default=lambda self: self.env.user.company_id.id,
     )
     team_ids = fields.Many2many(
         "fsm.team",

--- a/fieldservice/models/fsm_tag.py
+++ b/fieldservice/models/fsm_tag.py
@@ -15,9 +15,8 @@ class FSMTag(models.Model):
     company_id = fields.Many2one(
         "res.company",
         string="Company",
-        required=True,
+        required=False,
         index=True,
-        default=lambda self: self.env.user.company_id,
         help="Company related to this tag",
     )
 

--- a/fieldservice/models/fsm_team.py
+++ b/fieldservice/models/fsm_team.py
@@ -72,7 +72,7 @@ class FSMTeam(models.Model):
     company_id = fields.Many2one(
         "res.company",
         string="Company",
-        required=True,
+        required=False,
         index=True,
         default=lambda self: self.env.user.company_id,
         help="Company related to this team",


### PR DESCRIPTION
By default fsm_category, fsm_tag, fsm_team, fsm_stage must be shared by all companies.
In context of multi-company, default stages are attached to the main company at installation (imported) and not visible in the other companies.
This PR allows to use by default same satges, tags in all companies and allow to share team between company.
remark:
In some part of code we refer to imported stage (https://github.com/OCA/field-service/blob/14.0/fieldservice/models/fsm_order.py#L62)
