### PR TITLE
[12.0][FIX] Fix default datetime on FSM Order's request_early

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -89,7 +89,7 @@ class FSMOrder(models.Model):
                                   index=True, required=True)
     location_directions = fields.Char(string='Location Directions')
     request_early = fields.Datetime(string='Earliest Request Date',
-                                    default=datetime.now())
+                                    default=fields.Datetime.now)
     color = fields.Integer('Color Index')
     company_id = fields.Many2one(
         'res.company', string='Company', required=True, index=True,


### PR DESCRIPTION
Currently the request early field is filled with the date and time of the last installation.
With this fix, the request early (like other similar fields, even in the same model) is filled by default with the current date and time.