### PR TITLE
[12.0][FIX] Removed forced overwrite of fsm.order's Scheduled Date End

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -217,9 +217,6 @@ class FSMOrder(models.Model):
             req_date = req_date.replace(minute=0, second=0)
             vals.update({'scheduled_date_start': str(req_date),
                          'request_early': str(req_date)})
-        vals.update(
-            {'scheduled_date_end': self._context.get(
-                'default_scheduled_date_end') or False})
         self._calc_scheduled_dates(vals)
         if not vals.get('request_late'):
             if vals.get('priority') == '0':


### PR DESCRIPTION
Currently during FSM.Order's creation, the scheduled date end is forcibly overwritten by this call.
In addition, I cannot find any module that sets the "default_scheduled_date_end" key in the context that these lines refer to.

Not seeing the point of these lines of code anymore, I suggest removing them.