### PR TITLE
[12.0][IMP] Removed automatic Scheduled Date Start from FSM.Order Creation

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -89,7 +89,8 @@ class FSMOrder(models.Model):
                                   index=True, required=True)
     location_directions = fields.Char(string='Location Directions')
     request_early = fields.Datetime(string='Earliest Request Date',
-                                    default=fields.Datetime.now)
+                                    default=lambda _: fields.Datetime.now().
+                                    replace(second=0))
     color = fields.Integer('Color Index')
     company_id = fields.Many2one(
         'res.company', string='Company', required=True, index=True,
@@ -210,13 +211,6 @@ class FSMOrder(models.Model):
         if vals.get('name', _('New')) == _('New'):
             vals['name'] = self.env['ir.sequence'].next_by_code('fsm.order') \
                 or _('New')
-        if vals.get('request_early', False) and not vals.get(
-                'scheduled_date_start'):
-            req_date = fields.Datetime.from_string(vals['request_early'])
-            # Round scheduled date start
-            req_date = req_date.replace(minute=0, second=0)
-            vals.update({'scheduled_date_start': str(req_date),
-                         'request_early': str(req_date)})
         self._calc_scheduled_dates(vals)
         if not vals.get('request_late'):
             if vals.get('priority') == '0':

--- a/fieldservice/tests/test_fsm_order.py
+++ b/fieldservice/tests/test_fsm_order.py
@@ -43,13 +43,12 @@ class TestFSMOrder(TransactionCase):
             vals = order._compute_request_late(vals)
             self.assertEqual(vals['request_late'],
                              order.request_early + timedelta(days=late_days))
-        # Test set scheduled_date_start using request_early w/o time
-        self.assertEqual(order.scheduled_date_start,
-                         order.request_early.replace(minute=0, second=0))
+        # Test scheduled_date_start is not automatically set
+        self.assertEqual(order.scheduled_date_start, False)
         # Test scheduled_date_end = scheduled_date_start + duration (hrs)
         # Set date start
         order.scheduled_date_start = \
-            order.scheduled_date_start.replace(hour=0, minute=0, second=0)
+            fields.Datetime.now().replace(hour=0, minute=0, second=0)
         # Set duration
         duration = 10
         order.scheduled_duration = duration

--- a/fieldservice/tests/test_fsm_team.py
+++ b/fieldservice/tests/test_fsm_team.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2019 - TODAY, Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo import fields
 from odoo.tests.common import TransactionCase, Form
 
 
@@ -33,9 +34,8 @@ class FSMTeam(TransactionCase):
             orders += order
             order.person_id = i in todo['assigned'] and \
                 self.env.ref('fieldservice.person_1') or False
-            # TODO: after this https://github.com/OCA/field-service/issues/266
-            # assert should then be (5, 3, 1)
-            # order.scheduled_date_start = False
+            order.scheduled_date_start = i in todo['scheduled'] and \
+                fields.datetime.now() or False
         self.assertEqual((self.test_team.order_count,
                           self.test_team.order_need_assign_count,
-                          self.test_team.order_need_schedule_count), (5, 3, 0))
+                          self.test_team.order_need_schedule_count), (5, 3, 1))


### PR DESCRIPTION
Reasoning for this change:

- it is a bad default. If we accept all the default values, say I'm creating an order at 10.30am, both the request early and the scheduled_date_start are set to 10:00am. You'd be scheduling something for the past.
- if request_early should be stripped of minutes and seconds, it should be done when setting the default value, and not on the create method of the order, when it could be overwriting something manually set by the user
- Scheduling should be something that is done manually by a user, and not set automatically, even when the user unsets the field on purpose.
- Maybe a better solution could be to add a setting along the lines of "automatically schedule for the earliest date" and optionally activate this mechanism again. I would be willing to develop that if it's something you think would improve the module.
