### PR TITLE
[14.0] [IMP] fieldservice: toggle active FSMPerson

### DIFF
--- a/fieldservice/models/fsm_person.py
+++ b/fieldservice/models/fsm_person.py
@@ -31,6 +31,16 @@ class FSMPerson(models.Model):
     hide = fields.Boolean(default=False)
     mobile = fields.Char(string="Mobile")
     territory_ids = fields.Many2many("res.territory", string="Territories")
+    active = fields.Boolean(default=True)
+    active_partner = fields.Boolean(
+        related="partner_id.active", readonly=True, string="Partner is Active"
+    )
+
+    def toggle_active(self):
+        for person in self:
+            if not person.active and not person.partner_id.active:
+                person.partner_id.toggle_active()
+        super(FSMPerson, self).toggle_active()
 
     @api.model
     def _search(

--- a/fieldservice/tests/test_fsm_person.py
+++ b/fieldservice/tests/test_fsm_person.py
@@ -9,13 +9,14 @@ class FSMPerson(TransactionCase):
         super(FSMPerson, self).setUp()
         self.Worker = self.env["fsm.person"]
 
-    def test_fsm_location(self):
-        """Test createing new person
+    def test_fsm_person(self):
+        """Test creating new person
         - Default stage
         - Change stage
         - _search
+        - archive the person
         """
-        # Create an equipment
+        # Create a person
         view_id = "fieldservice.fsm_person_form"
         with Form(self.Worker, view=view_id) as f:
             f.name = "Worker A"
@@ -30,5 +31,9 @@ class FSMPerson(TransactionCase):
         self.assertTrue(worker.hide)  # hide as max stage
         worker.previous_stage()
         self.assertEqual(worker.stage_id, self.env.ref("fieldservice.worker_stage_2"))
-
+        # Test search
         # TODO: https://github.com/OCA/field-service/issues/265
+        # Test archive
+        worker.toggle_active()
+        self.assertEqual(worker.active, False)
+        self.assertEqual(worker.active_partner, True)

--- a/fieldservice/tests/test_fsm_wizard.py
+++ b/fieldservice/tests/test_fsm_wizard.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2019 - TODAY, Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
 
@@ -47,6 +48,13 @@ class FSMWizard(TransactionCase):
         # check if 'Test Partner' creation successful and fields copied over
         self.assertEqual(self.test_person.phone, self.wiz_person.phone)
         self.assertEqual(self.test_person.email, self.wiz_person.email)
+
+        # archive the the new FSM Person
+        self.wiz_person.toggle_active()
+
+        # check that a person is not created when there is an archived person
+        with self.assertRaises(UserError):
+            self.Wizard.action_convert_person(self.test_partner)
 
     def test_convert_sublocation(self):
         # convert Parent Partner to FSM Location

--- a/fieldservice/views/fsm_person.xml
+++ b/fieldservice/views/fsm_person.xml
@@ -58,7 +58,45 @@
                     />
                 </header>
                 <sheet>
-                    <div name="button_box" class="oe_button_box" />
+                    <div name="button_box" class="oe_button_box">
+                        <button
+                            name="toggle_active"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-check"
+                        >
+                            <field
+                                name="active"
+                                widget="boolean_button"
+                                options='{"terminology": "active"}'
+                            />
+                        </button>
+                    </div>
+                    <field
+                        name="active_partner"
+                        required="0"
+                        readonly="1"
+                        invisible="1"
+                    />
+                    <div
+                        class="alert alert-info text-center o_form_header"
+                        attrs="{'invisible': [
+                            '|', '|',
+                            '&amp;', ('active', '=', True), ('active_partner', '=', True),
+                            '&amp;', ('active', '=', False), ('active_partner', '=', False),
+                            '&amp;', ('active', '=', True), ('active_partner', '=', False),
+                        ]}"
+                        role="alert"
+                    >
+                        <a class="close" data-dismiss="alert" href="#">x</a>
+                        <div>
+                            <strong
+                            >The contact linked to this user is still active</strong>
+                        </div>
+                        <div>You can archive the contact
+                            <field name="partner_id" required="0" readonly="1" />
+                        </div>
+                    </div>
                     <label for="name" class="oe_edit_only" />
                     <h1>
                         <field name="name" required="True" />

--- a/fieldservice/wizard/fsm_wizard.py
+++ b/fieldservice/wizard/fsm_wizard.py
@@ -43,7 +43,8 @@ class FSMWizard(models.TransientModel):
             )
 
     def action_convert_person(self, partner):
-        res = self.env["fsm.person"].search_count([("partner_id", "=", partner.id)])
+        Person = self.env["fsm.person"].with_context(active_test=False)
+        res = Person.search_count([("partner_id", "=", partner.id)])
         if res == 0:
             self.env["fsm.person"].create({"partner_id": partner.id})
             partner.write({"fsm_person": True})


### PR DESCRIPTION
This PR allows you to archive field service workers, while keeping the associated partner active

**Archive button added to worker form**
![Screenshot from 2021-11-09 10-23-27](https://user-images.githubusercontent.com/25710115/140952672-ad0e5d36-cb51-416c-8da8-a19674497e41.png)

**Form after a worker is archived**
![Screenshot from 2021-11-09 10-23-36](https://user-images.githubusercontent.com/25710115/140952695-c61d1b6a-696e-476a-acff-f6462cca27e9.png)

