### PR TITLE
[FIX] fieldservice: ValueError: unconverted data remains

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -367,7 +367,7 @@ class FSMOrder(models.Model):
             date_to_with_delta = fields.Datetime.from_string(
                 self.scheduled_date_end
             ) - timedelta(hours=self.scheduled_duration)
-            self.date_start = str(date_to_with_delta)
+            self.date_start = str(date_to_with_delta.replace(microsecond=0))
 
     @api.onchange("scheduled_duration")
     def onchange_scheduled_duration(self):
@@ -375,7 +375,7 @@ class FSMOrder(models.Model):
             date_to_with_delta = fields.Datetime.from_string(
                 self.scheduled_date_start
             ) + timedelta(hours=self.scheduled_duration)
-            self.scheduled_date_end = str(date_to_with_delta)
+            self.scheduled_date_end = str(date_to_with_delta.replace(microsecond=0))
 
     def copy_notes(self):
         old_desc = self.description


### PR DESCRIPTION
Error:
Odoo Server Error

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 684, in dispatch
    result = self._call_function(**self.params)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 360, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 348, in checked_call
    result = self.endpoint(*a, **kw)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 913, in __call__
    return self.method(*args, **kw)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 532, in response_wrap
    response = f(*args, **kw)
  File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/main.py", line 1389, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/main.py", line 1381, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 396, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 383, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/odoo/models.py", line 6240, in onchange
    record._onchange_eval(name, field_onchange[name], result)
  File "/usr/lib/python3/dist-packages/odoo/models.py", line 5982, in _onchange_eval
    method_res = method(self)
  File "/odoo/addons/fieldservice/models/fsm_order.py", line 378, in onchange_scheduled_duration
    self.scheduled_date_end = str(date_to_with_delta)
  File "/usr/lib/python3/dist-packages/odoo/fields.py", line 1115, in __set__
    self.write(new_records, value)
  File "/usr/lib/python3/dist-packages/odoo/fields.py", line 928, in write
    cache_value = self.convert_to_cache(value, records)
  File "/usr/lib/python3/dist-packages/odoo/fields.py", line 1934, in convert_to_cache
    return self.to_datetime(value)
  File "/usr/lib/python3/dist-packages/odoo/fields.py", line 1914, in to_datetime
    return datetime.strptime(value, DATETIME_FORMAT[:len(value)-2])
  File "/usr/lib/python3.8/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/usr/lib/python3.8/_strptime.py", line 352, in _strptime
    raise ValueError("unconverted data remains: %s" %
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 640, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 316, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: unconverted data remains: .814967