### PR TITLE
Correcting acentuation portugues to be redable

### DIFF
--- a/fieldservice_vehicle/i18n/pt_BR.po
+++ b/fieldservice_vehicle/i18n/pt_BR.po
@@ -19,7 +19,7 @@ msgstr ""
 #. module: fieldservice_vehicle
 #: model_terms:ir.actions.act_window,help:fieldservice_vehicle.action_fsm_vehicle
 msgid "Add a Field Service Vehicle here."
-msgstr "Adicione um Ve??culo de Servi??o de Campo aqui."
+msgstr "Adicione um Veiculo de Servico de Campo aqui."
 
 #. module: fieldservice_vehicle
 #: model:ir.model.fields,field_description:fieldservice_vehicle.field_fsm_vehicle__person_id
@@ -39,7 +39,7 @@ msgstr "Criado em"
 #. module: fieldservice_vehicle
 #: model:ir.model.fields,field_description:fieldservice_vehicle.field_fsm_person__vehicle_id
 msgid "Default Vehicle"
-msgstr "Ve??culo Padr??o"
+msgstr "Veiculo Padrao"
 
 #. module: fieldservice_vehicle
 #: model:ir.model.fields,field_description:fieldservice_vehicle.field_fsm_vehicle__display_name
@@ -49,22 +49,22 @@ msgstr "Exibir Nome"
 #. module: fieldservice_vehicle
 #: model:ir.model,name:fieldservice_vehicle.model_fsm_order
 msgid "Field Service Order"
-msgstr "Ordem de Servi??o de Campo"
+msgstr "Ordem de Servico de Campo"
 
 #. module: fieldservice_vehicle
 #: model:ir.model,name:fieldservice_vehicle.model_fsm_vehicle
 msgid "Field Service Vehicle"
-msgstr "Ve??culo de Servi??o de Campo"
+msgstr "Veiculo de Servico de Campo"
 
 #. module: fieldservice_vehicle
 #: model:ir.actions.act_window,name:fieldservice_vehicle.action_fsm_vehicle
 msgid "Field Service Vehicles"
-msgstr "Ve??culos de Servi??o de Campo"
+msgstr "Veiculos de Servico de Campo"
 
 #. module: fieldservice_vehicle
 #: model:ir.model,name:fieldservice_vehicle.model_fsm_person
 msgid "Field Service Worker"
-msgstr "Trabalhador do Servi??o de Campo"
+msgstr "Trabalhador do Servico de Campo"
 
 #. module: fieldservice_vehicle
 #: model:ir.model.fields,field_description:fieldservice_vehicle.field_fsm_vehicle__id
@@ -74,22 +74,22 @@ msgstr "ID"
 #. module: fieldservice_vehicle
 #: model:ir.model.fields,field_description:fieldservice_vehicle.field_fsm_vehicle____last_update
 msgid "Last Modified on"
-msgstr "??ltima Modifica????o Feita em"
+msgstr "Ultima Modificacao Feita em"
 
 #. module: fieldservice_vehicle
 #: model:ir.model.fields,field_description:fieldservice_vehicle.field_fsm_vehicle__write_uid
 msgid "Last Updated by"
-msgstr "??ltima Atualiza????o Feita por"
+msgstr "Ultima Atualizacao Feita por"
 
 #. module: fieldservice_vehicle
 #: model:ir.model.fields,field_description:fieldservice_vehicle.field_fsm_vehicle__write_date
 msgid "Last Updated on"
-msgstr "??ltima Atualiza????o Feita em"
+msgstr "Ultima Atualizacao Feita em"
 
 #. module: fieldservice_vehicle
 #: model:res.groups,name:fieldservice_vehicle.group_fsm_vehicle
 msgid "Manage Vehicles"
-msgstr "Gerenciar Ve??culos"
+msgstr "Gerenciar Veiculos"
 
 #. module: fieldservice_vehicle
 #: model:ir.model.fields,field_description:fieldservice_vehicle.field_fsm_vehicle__name
@@ -100,12 +100,12 @@ msgstr "Nome"
 #: model:ir.model.fields,field_description:fieldservice_vehicle.field_fsm_order__vehicle_id
 #: model_terms:ir.ui.view,arch_db:fieldservice_vehicle.fsm_vehicle_form_view
 msgid "Vehicle"
-msgstr "Ve??culo"
+msgstr "Veiculo"
 
 #. module: fieldservice_vehicle
 #: model:ir.model.constraint,message:fieldservice_vehicle.constraint_fsm_vehicle_name_uniq
 msgid "Vehicle name already exists!"
-msgstr "O nome do ve??culo j?? existe!"
+msgstr "O nome do veiculo ja existe!"
 
 #. module: fieldservice_vehicle
 #: model:ir.actions.act_window,name:fieldservice_vehicle.action_fsm_report_vehicle
@@ -115,9 +115,9 @@ msgstr "O nome do ve??culo j?? existe!"
 #: model_terms:ir.ui.view,arch_db:fieldservice_vehicle.fsm_vehicle_pivot_view
 #: model_terms:ir.ui.view,arch_db:fieldservice_vehicle.fsm_vehicle_tree_view
 msgid "Vehicles"
-msgstr "Ve??culos"
+msgstr "Veiculos"
 
 #. module: fieldservice_vehicle
 #: model_terms:ir.actions.act_window,help:fieldservice_vehicle.action_fsm_report_vehicle
 msgid "Vehicles Report"
-msgstr "Relat??rio de Ve??culos"
+msgstr "Relatorio de Veiculos"


### PR DESCRIPTION
This is trying to prevent encoding error while portugues version is not finished to make the fields readable by the user

![Screenshot from 2021-12-08 16-19-35](https://user-images.githubusercontent.com/38361760/145270440-e0ee1933-5f8b-4762-88db-4c6ba4d999bb.png)
Any other acentuation problems