### PR TITLE
[12.0][FIX] Recalculate geolocation on any coordinate change

### DIFF
--- a/fieldservice_geoengine/models/fsm_location.py
+++ b/fieldservice_geoengine/models/fsm_location.py
@@ -46,7 +46,7 @@ class FSMLocation(models.Model):
     @api.multi
     def write(self, vals):
         res = super(FSMLocation, self).write(vals)
-        if ('partner_latitude' in vals) and ('partner_longitude' in vals):
+        if ('partner_latitude' in vals) or ('partner_longitude' in vals):
             self.shape = fields.GeoPoint.from_latlon(
                 cr=self.env.cr,
                 latitude=vals['partner_latitude'],


### PR DESCRIPTION
As it is, geolocation is only recalculated if both coordinates are changed at the same time.

With this PR, geolocation is recalculated even if only one of the two coordinates changes.