### PR TITLE
[12.0][FIX]Removed model.read() in fieldservice_stage_validation

### DIFF
--- a/fieldservice_stage_validation/models/fsm_equipment.py
+++ b/fieldservice_stage_validation/models/fsm_equipment.py
@@ -11,12 +11,10 @@ class FSMEquipment(models.Model):
     def _validate_stage_fields(self):
         for rec in self:
             stage = rec.stage_id
-            field_ids = stage.validate_field_ids
-            field_names = [x.name for x in field_ids]
-            values = rec.read(field_names)
+            field_names = [x.name for x in stage.validate_field_ids]
 
             for name in field_names:
-                if not values[0][name]:
+                if not rec[name]:
                     raise ValidationError(_('Cannot move to stage "%s" '
                                             'until the "%s" field is set.'
                                             % (stage.name, name)))

--- a/fieldservice_stage_validation/models/fsm_location.py
+++ b/fieldservice_stage_validation/models/fsm_location.py
@@ -11,12 +11,10 @@ class FSMLocation(models.Model):
     def _validate_stage_fields(self):
         for rec in self:
             stage = rec.stage_id
-            field_ids = stage.validate_field_ids
-            field_names = [x.name for x in field_ids]
-            values = rec.read(field_names)
+            field_names = [x.name for x in stage.validate_field_ids]
 
             for name in field_names:
-                if not values[0][name]:
+                if not rec[name]:
                     raise ValidationError(_('Cannot move to stage "%s" '
                                             'until the "%s" field is set.'
                                             % (stage.name, name)))

--- a/fieldservice_stage_validation/models/fsm_order.py
+++ b/fieldservice_stage_validation/models/fsm_order.py
@@ -11,12 +11,10 @@ class FSMOrder(models.Model):
     def _validate_stage_fields(self):
         for rec in self:
             stage = rec.stage_id
-            field_ids = stage.validate_field_ids
-            field_names = [x.name for x in field_ids]
-            values = rec.read(field_names)
+            field_names = [x.name for x in stage.validate_field_ids]
 
             for name in field_names:
-                if not values[0][name]:
+                if not rec[name]:
                     raise ValidationError(_('Cannot move to stage "%s" '
                                             'until the "%s" field is set.'
                                             % (stage.name, name)))

--- a/fieldservice_stage_validation/models/fsm_person.py
+++ b/fieldservice_stage_validation/models/fsm_person.py
@@ -11,12 +11,10 @@ class FSMPerson(models.Model):
     def _validate_stage_fields(self):
         for rec in self:
             stage = rec.stage_id
-            field_ids = stage.validate_field_ids
-            field_names = [x.name for x in field_ids]
-            values = rec.read(field_names)
+            field_names = [x.name for x in stage.validate_field_ids]
 
             for name in field_names:
-                if not values[0][name]:
+                if not rec[name]:
                     raise ValidationError(_('Cannot move to stage "%s" '
                                             'until the "%s" field is set.'
                                             % (stage.name, name)))


### PR DESCRIPTION
Currently installing fieldservice_stage_validation means that e.g. the stored related fields "district", :territory", "region" etc. on the fsm.order are not set correctly whenever the constraint validation method is also called, such as on model creation. There are probably other, similar side effects too.

This is because the call to model.read() invalidates the model's cache before it can be written to the DB.

It's enough to replace model.read() with an equivalent access to the model's field to fix it.