### PR TITLE
[14.0][FIX] fieldservice: worker create in developer mode

### DIFF
--- a/fieldservice/views/fsm_person.xml
+++ b/fieldservice/views/fsm_person.xml
@@ -107,6 +107,7 @@
                                 name="partner_id"
                                 groups="base.group_no_one"
                                 readonly="1"
+                                required="False"
                             />
                             <field
                                 name="category_ids"


### PR DESCRIPTION
While in developer mode if you try to add a worker an error occurs because the related partner is mandatory but with false value.
I use the same solution fo the similar #887