### PR TITLE
[13.0][FIX] fieldservice_sale - confirm quotation with section or note lines

### DIFF
--- a/fieldservice_sale/models/sale_order.py
+++ b/fieldservice_sale/models/sale_order.py
@@ -139,7 +139,8 @@ class SaleOrder(models.Model):
         """ On SO confirmation, some lines generate field service orders. """
         result = super(SaleOrder, self)._action_confirm()
         if any(
-            sol.product_id.field_service_tracking != "no" for sol in self.order_line
+            sol.product_id.field_service_tracking != "no" and not sol.display_type
+            for sol in self.order_line
         ):
             if not self.fsm_location_id:
                 raise ValidationError(_("FSM Location must be set"))


### PR DESCRIPTION
When you use a product that should not create a fsm order and add a section line or a note line in a quotation, odoo raises an error asking for a FSM Location when you try to confirm the quotation. But you should be able to confirm the sale order without FSM Location since there will not be any field service creation.

![fieldservicenoproduct](https://user-images.githubusercontent.com/32102436/157699800-368209df-472a-4a84-9554-69db6a187aef.png)
![saleorderno](https://user-images.githubusercontent.com/32102436/157699820-6984fabc-c5fb-40e8-b461-15961b5142a1.png)

