### PR TITLE
[14.0] [FIX] fieldservice_recurring: Attempt to fix daylight saving time jumps

### DIFF
--- a/fieldservice_recurring/models/fsm_frequency.py
+++ b/fieldservice_recurring/models/fsm_frequency.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2019 Brian McMaster, Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import pytz
 from dateutil.rrule import (
     DAILY,
     FR,
@@ -119,15 +120,42 @@ class FSMFrequency(models.Model):
     def _get_rrule(self, dtstart=None, until=None):
         self.ensure_one()
         freq = FREQUENCIES[self.interval_type]
-        return rrule(
-            freq,
-            interval=self.interval,
-            dtstart=dtstart,
-            until=until,
-            byweekday=self._byweekday(),
-            bymonth=self._bymonth(),
-            bymonthday=self._bymonthday(),
-            bysetpos=self._bysetpos(),
+        # localize dtstart and until to user timezone
+        tz = pytz.timezone(self._context.get("tz", self.env.user.tz or "UTC"))
+
+        if dtstart:
+            dtstart = pytz.timezone("UTC").localize(dtstart).astimezone(tz)
+        if until:
+            until = pytz.timezone("UTC").localize(until).astimezone(tz)
+            # We force until in the starting timezone to avoid incoherent results
+            until = tz.normalize(until.replace(tzinfo=dtstart.tzinfo))
+
+        return (
+            # Replace original timezone with current date timezone
+            # without changing the time and force it back to UTC,
+            # this will keep the same final time even in case of
+            # daylight saving time change
+            #
+            # for instance recurring weekly
+            # from 2022-03-21 15:00:00+01:00 to 2022-04-11 15:30:00+02:00
+            # will give:
+            #
+            # utc naive -> datetime timezone aware
+            # 2022-03-21 14:00:00 -> 2022-03-21 15:00:00+01:00
+            # 2022-03-28 13:00:00 -> 2022-03-28 15:00:00+02:00
+            date.replace(tzinfo=tz.normalize(date).tzinfo)
+            .astimezone(pytz.UTC)
+            .replace(tzinfo=None)
+            for date in rrule(
+                freq,
+                interval=self.interval,
+                dtstart=dtstart,
+                until=until,
+                byweekday=self._byweekday(),
+                bymonth=self._bymonth(),
+                bymonthday=self._bymonthday(),
+                bysetpos=self._bysetpos(),
+            )
         )
 
     def _byweekday(self):

--- a/fieldservice_recurring/tests/test_fsm_recurring.py
+++ b/fieldservice_recurring/tests/test_fsm_recurring.py
@@ -72,7 +72,7 @@ class FSMRecurringCase(TransactionCase):
             {
                 "fsm_frequency_set_id": fr_set.id,
                 "location_id": self.test_location.id,
-                "start_date": fields.Datetime.today(),
+                "start_date": fields.Datetime.now().replace(hour=12),
             }
         )
         recurring.action_start()
@@ -114,7 +114,7 @@ class FSMRecurringCase(TransactionCase):
             {
                 "fsm_frequency_set_id": fr_set.id,
                 "location_id": self.test_location.id,
-                "start_date": fields.Datetime.today(),
+                "start_date": fields.Datetime.now().replace(hour=12),
             }
         )
         recurring.action_start()
@@ -125,7 +125,7 @@ class FSMRecurringCase(TransactionCase):
         x = False
         for d in all_dates:
             if x:
-                diff_days = (d - x).days
+                diff_days = (d.date() - x.date()).days
                 self.assertEqual(diff_days, 21)
             x = d
 
@@ -157,7 +157,7 @@ class FSMRecurringCase(TransactionCase):
             {
                 "fsm_frequency_set_id": fr_set.id,
                 "location_id": self.test_location.id,
-                "start_date": fields.Datetime.today(),
+                "start_date": fields.Datetime.now().replace(hour=12),
             }
         )
         recurring.action_start()


### PR DESCRIPTION
Use timezone aware rrule and normalize recurring dates to avoid hour jumps during daylight saving time changes.

Without this PR when recurring weekly between 2022-03-21 15:00:00 and 2022-04-11 15:30:00 in timezone Europe/Paris we get:
```
2022-03-21 15:00:00
2022-03-28 16:00:00
```
with it we get:
```
2022-03-21 15:00:00
2022-03-28 15:00:00
```