### PR TITLE
[14][FIX] fieldservice_recurring: fsm_order_ids should be readonly

### DIFF
--- a/fieldservice_recurring/views/fsm_recurring.xml
+++ b/fieldservice_recurring/views/fsm_recurring.xml
@@ -87,8 +87,8 @@
                         </group>
                     </group>
                     <group string="Orders">
-                        <field name="fsm_order_ids" widget="many2many" nolabel="1">
-                            <tree create="0" delete="0">
+                        <field name="fsm_order_ids" nolabel="1">
+                            <tree create="false">
                                 <field name="name" />
                                 <field name="stage_id" />
                                 <field name="scheduled_date_start" />


### PR DESCRIPTION
in the UI, it should not be allowed to select orders to be added to recurring.