### PR TITLE
[14.0][IMP] fieldservice_recurring: refactor stages

### DIFF
--- a/fieldservice_recurring/__manifest__.py
+++ b/fieldservice_recurring/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Field Service Recurring Work Orders",
     "summary": "Manage recurring Field Service orders",
-    "version": "14.0.1.8.0",
+    "version": "14.0.2.0.0",
     "category": "Field Service",
     "author": "Brian McMaster, "
     "Open Source Integrators, "

--- a/fieldservice_recurring/__manifest__.py
+++ b/fieldservice_recurring/__manifest__.py
@@ -21,6 +21,7 @@
         "views/fsm_order.xml",
         "views/fsm_recurring_template.xml",
         "views/fsm_recurring.xml",
+        "views/fsm_team.xml",
         "data/recurring_cron.xml",
     ],
     "demo": [

--- a/fieldservice_recurring/migrations/14.0.2.0.0/pre-migration.py
+++ b/fieldservice_recurring/migrations/14.0.2.0.0/pre-migration.py
@@ -1,0 +1,7 @@
+# Copyright (C) 2022 Raphaël Reverdy <raphael.reverdy@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+def migrate(env, version):
+    env.execute("UPDATE fsm_recurring SET state = 'close' WHERE state = 'cancel';")
+    env.execute("UPDATE fsm_recurring SET state = 'progress' WHERE state = 'pending';")

--- a/fieldservice_recurring/models/__init__.py
+++ b/fieldservice_recurring/models/__init__.py
@@ -7,4 +7,5 @@ from . import (
     fsm_frequency,
     fsm_recurring_template,
     fsm_recurring,
+    fsm_team,
 )

--- a/fieldservice_recurring/models/fsm_team.py
+++ b/fieldservice_recurring/models/fsm_team.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2022 Raphaël Reverdy (Akretion)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class FSMTeam(models.Model):
+    _inherit = "fsm.team"
+
+    def _compute_recurring_draft_count(self):
+        order_data = self.env["fsm.recurring"].read_group(
+            [
+                ("team_id", "in", self.ids),
+                ("state", "=", "draft"),
+            ],
+            ["team_id"],
+            ["team_id"],
+        )
+        result = {data["team_id"][0]: int(data["team_id_count"]) for data in order_data}
+        for team in self:
+            team.recurring_draft_count = result.get(team.id, 0)
+
+    recurring_draft_count = fields.Integer(
+        compute="_compute_recurring_draft_count", string="Recurring in draft"
+    )

--- a/fieldservice_recurring/views/fsm_recurring.xml
+++ b/fieldservice_recurring/views/fsm_recurring.xml
@@ -28,28 +28,19 @@
                     <button
                         id="action_start"
                         name="action_start"
-                        string="Confirm"
+                        string="Start"
                         class="oe_highlight"
                         type="object"
                         groups="fieldservice.group_fsm_dispatcher"
-                        attrs="{'invisible': [('state', '!=', 'draft')]}"
+                        attrs="{'invisible': [('state', 'in',('close', 'progress'))]}"
                     />
                     <button
-                        id="action_renew"
-                        name="action_renew"
-                        string="Renew"
-                        class="oe_highlight"
+                        id="action_suspend"
+                        name="action_suspend"
+                        string="Suspend"
                         type="object"
                         groups="fieldservice.group_fsm_dispatcher"
-                        attrs="{'invisible': [('state', '!=', 'pending')]}"
-                    />
-                    <button
-                        id="action_cancel"
-                        name="action_cancel"
-                        string="Cancel"
-                        type="object"
-                        groups="fieldservice.group_fsm_dispatcher"
-                        attrs="{'invisible': [('state', 'in', ('close', 'cancel'))]}"
+                        attrs="{'invisible': [('state', 'in', ('draft', 'close'))]}"
                     />
                     <field name="state" widget="statusbar" />
                 </header>
@@ -143,19 +134,14 @@
                     name="progress"
                 />
                 <filter
-                    string="To Renew"
-                    domain="[('state', '=', 'pending')]"
-                    name="renew"
-                />
-                <filter
                     string="Closed"
                     domain="[('state', '=', 'close')]"
                     name="closed"
                 />
                 <filter
-                    string="Cancelled"
-                    domain="[('state', '=', 'cancel')]"
-                    name="cancelled"
+                    string="Suspended"
+                    domain="[('state', '=', 'suspend')]"
+                    name="suspended"
                 />
                 <separator />
                 <group expand="0" string="Group By">

--- a/fieldservice_recurring/views/fsm_team.xml
+++ b/fieldservice_recurring/views/fsm_team.xml
@@ -1,0 +1,55 @@
+<odoo>
+    <record id="action_recurring_tree" model="ir.actions.act_window">
+        <field name="name">Recurring Orders</field>
+        <field name="res_model">fsm.recurring</field>
+        <field name="context">{}</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[('team_id', '=', active_id)]</field>
+    </record>
+    <record model="ir.ui.view" id="view_team_kanban_recurring">
+        <field name="model">fsm.team</field>
+        <field name="inherit_id" ref="fieldservice.view_team_kanban" />
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="recurring_draft_count" />
+            </field>
+            <xpath
+                expr="//div[hasclass('container','o_kanban_card_content')]"
+                position="inside"
+            >
+                <div class="row">
+                    <div class="col-6 o_kanban_primary_right">
+                        <div class="row">
+                            <div class="col-9">
+                                <a
+                                    name="%(fieldservice_recurring.action_recurring_tree)d"
+                                    type="action"
+                                    context="{'search_default_progress': 1}"
+                                >
+                                    Recurring Orders
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="col-6 o_kanban_primary_left">
+                        <div class="row">
+                            <div class="col-9">
+                                 <a
+                                    name="%(fieldservice_recurring.action_recurring_tree)d"
+                                    type="action"
+                                    context="{'search_default_draft': 1}"
+                                >
+                                Draft Recurring
+                                </a>
+                            </div>
+                            <div class="col-3">
+                                <t t-esc="record.recurring_draft_count.value" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Stages are now:
- draft: not started yet
- progress: orders are and will continue to be generated
- suspend: it can continue to generate orders but it has been put on pause for some reason
- close: no new orders will / can be generated

```dot

digraph {
draft -> progress -> suspend -> close
suspend -> progress
}
```

Why this change ?

- it was impossible to go back to progress after cancel
- pending / renew is too opinated to be in a base module,
- renew duration was hardcoded

(btw renew can be implemented by a renew_date instead of a stage
in a dedicated module)
