### PR TITLE
[14.0][FIX] fieldservice: Fix limit issue

### DIFF
--- a/fieldservice/models/res_partner.py
+++ b/fieldservice/models/res_partner.py
@@ -15,7 +15,6 @@ class ResPartner(models.Model):
         string="Related FS Location",
         inverse_name="partner_id",
         readonly=1,
-        limit=1,
     )
     service_location_id = fields.Many2one(
         "fsm.location", string="Primary Service Location"


### PR DESCRIPTION
without this fix
some_partner.child_ids.mapped('fsm_location_id')
return just one rec instead of all the expected records