### PR TITLE
[12.0][FIX] Fix order confirmation when there are note lines or sections

### DIFF
--- a/fieldservice_sale/README.rst
+++ b/fieldservice_sale/README.rst
@@ -124,6 +124,9 @@ Contributors
 * Brian McMaster <brian@mcmpest.com>
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
 * Clément Mombereau <clement.mombereau@akretion.com>
+* Trey <https://www.trey.es>
+
+  * Miguel Poyatos <miguel@trey.es>
 
 Maintainers
 ~~~~~~~~~~~

--- a/fieldservice_sale/models/sale_order.py
+++ b/fieldservice_sale/models/sale_order.py
@@ -126,7 +126,7 @@ class SaleOrder(models.Model):
         """ On SO confirmation, some lines generate field service orders. """
         result = super(SaleOrder, self)._action_confirm()
         if any(sol.product_id.field_service_tracking != 'no'
-               for sol in self.order_line):
+               for sol in self.order_line if sol.product_id):
             if not self.fsm_location_id:
                 raise ValidationError(_("FSM Location must be set"))
             self.order_line._field_service_generation()

--- a/fieldservice_sale/tests/test_fsm_sale_common.py
+++ b/fieldservice_sale/tests/test_fsm_sale_common.py
@@ -95,3 +95,13 @@ class TestFSMSale(TestCommonSaleNoChart):
             'field_service_tracking': 'line',
             'fsm_order_template_id': cls.fsm_template_4.id,
         })
+        cls.standard_service_1 = cls.env['product.product'].create({
+            'name': 'Standard service #1',
+            'categ_id': cls.env.ref('product.product_category_3').id,
+            'standard_price': 25.0,
+            'list_price': 50.0,
+            'type': 'service',
+            'uom_id': cls.env.ref('uom.product_uom_unit').id,
+            'uom_po_id': cls.env.ref('uom.product_uom_unit').id,
+            'invoice_policy': 'delivery',
+        })

--- a/fieldservice_sale/tests/test_fsm_sale_order.py
+++ b/fieldservice_sale/tests/test_fsm_sale_order.py
@@ -117,6 +117,24 @@ class TestFSMSaleOrder(TestFSMSale):
             'order_id': cls.sale_order_4.id,
             'tax_id': False,
         })
+        cls.sale_order_5 = SaleOrder.create({
+            'partner_id': cls.partner_customer_usd.id,
+            'pricelist_id': cls.pricelist_usd.id,
+        })
+        cls.sol_service_standard_line_1 = cls.env['sale.order.line'].create({
+            'order_id': cls.sale_order_5.id,
+            'name': cls.standard_service_1.name,
+            'product_id': cls.standard_service_1.id,
+            'product_uom_qty': 1,
+            'product_uom': cls.standard_service_1.uom_id.id,
+            'price_unit': cls.standard_service_1.list_price,
+            'tax_id': False,
+        })
+        cls.sol_section_line_1 = cls.env['sale.order.line'].create({
+            'name': cls.fsm_per_line_1.name,
+            'display_type': 'line_note',
+            'order_id': cls.sale_order_5.id,
+        })
 
     def _isp_account_installed(self):
         """ Checks if module is installed which will require more
@@ -384,3 +402,14 @@ class TestFSMSaleOrder(TestFSMSale):
         self.assertEqual(
             len(inv_fsm_orders.ids), 3,
             'FSM Sale: There should be 3 orders for 3 invoices')
+
+    def test_sale_order_5(self):
+        """ Test sale order 5 flow from quotation to sale.
+            - Check no FSM sale flow.
+        """
+        self.sale_order_5.action_confirm()
+        inv_id = self.sale_order_5.action_invoice_create()
+        invoices = self.env['account.invoice'].browse(inv_id)
+        self.assertEqual(
+            len(invoices.ids), 1,
+            'Sale Order 5 should create 1 invoice')


### PR DESCRIPTION
If we add a line type note or section in a quotation and try to confirm it. It is not an FSM quotation but it will return a validation error, because the line.product_id is 'False' and therefore the `sol.product_id.field_service_tracking` validation will also be `False`, different from `no`. This PR solves it.

![image](https://user-images.githubusercontent.com/65534329/177758118-8fa5f09b-5118-4563-87f8-4fdfbf1033c9.png)
