### PR TITLE
[FIX] fieldservice_geoengine: Recompute geopoint if either latitude or longitude didn't change

### DIFF
--- a/fieldservice_geoengine/models/fsm_location.py
+++ b/fieldservice_geoengine/models/fsm_location.py
@@ -49,7 +49,8 @@ class FSMLocation(models.Model):
         if ('partner_latitude' in vals) or ('partner_longitude' in vals):
             self.shape = fields.GeoPoint.from_latlon(
                 cr=self.env.cr,
-                latitude=vals['partner_latitude'],
-                longitude=vals['partner_longitude'])
+                latitude=self.partner_latitude,
+                longitude=self.partner_longitude
+            )
             self._update_order_geometries()
         return res


### PR DESCRIPTION
If only one of longitude or latitude didn't change, the method would raise an error (as they wouldn't be in the vals).

But we're after the write, so we can just take the values from the object directly and ensure that the values always exist.