### PR TITLE
[FIX] fieldservice: Duplicate/copy method

### DIFF
--- a/fieldservice/models/fsm_equipment.py
+++ b/fieldservice/models/fsm_equipment.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018 - TODAY, Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 class FSMEquipment(models.Model):
@@ -102,3 +102,10 @@ class FSMEquipment(models.Model):
             self.hide = True
         else:
             self.hide = False
+
+    def copy(self, default=None):
+        if default is None:
+            default = {}
+        if "name" not in default:
+            default["name"] = self.name + _(" (copy)")
+        return super().copy(default=default)

--- a/fieldservice/tests/test_fsm_equipment.py
+++ b/fieldservice/tests/test_fsm_equipment.py
@@ -51,3 +51,10 @@ class FSMEquipment(TransactionCase):
         self.assertEqual(
             equipment.stage_id, self.env.ref("fieldservice.equipment_stage_2")
         )
+
+    def test_fsm_equipment_copy(self):
+        equipment = self.Equipment.create({"name": "Equipment"})
+        equipment_copy = equipment.copy()
+        self.assertEqual(equipment_copy.name, "Equipment (copy)")
+        equipment_copy = equipment.copy({"name": "Test"})
+        self.assertEqual(equipment_copy.name, "Test")


### PR DESCRIPTION
Don't show

> Equipment name already exists!

when duplicating/copying an equipment.