### PR TITLE
[IMP] fieldservice_recurring: Use location_id tz

### DIFF
--- a/fieldservice_recurring/models/fsm_frequency.py
+++ b/fieldservice_recurring/models/fsm_frequency.py
@@ -117,12 +117,12 @@ class FSMFrequency(models.Model):
                 if not (1 <= rec.month_day <= 31):
                     raise UserError(_("'Day of Month must be between 1 and 31"))
 
-    def _get_rrule(self, dtstart=None, until=None):
+    def _get_rrule(self, dtstart=None, until=None, tz=None):
         self.ensure_one()
         freq = FREQUENCIES[self.interval_type]
         # localize dtstart and until to user timezone
-        tz = (
-            pytz.timezone(self._context.get("tz", None) or self.env.user.tz) or pytz.UTC
+        tz = pytz.timezone(
+            tz or self._context.get("tz", None) or self.env.user.tz or "UTC"
         )
 
         if dtstart:

--- a/fieldservice_recurring/models/fsm_frequency_set.py
+++ b/fieldservice_recurring/models/fsm_frequency_set.py
@@ -36,12 +36,12 @@ class FSMFrequencySet(models.Model):
            that an event can be done""",
     )
 
-    def _get_rruleset(self, dtstart=None, until=None):
+    def _get_rruleset(self, dtstart=None, until=None, tz=None):
         self.ensure_one()
         rset = rruleset()
         for rule in self.fsm_frequency_ids:
             if not rule.is_exclusive:
-                rset.rrule(rule._get_rrule(dtstart, until))
+                rset.rrule(rule._get_rrule(dtstart, until, tz))
             else:
-                rset.exrule(rule._get_rrule(dtstart))
+                rset.exrule(rule._get_rrule(dtstart, tz=tz))
         return rset

--- a/fieldservice_recurring/models/fsm_recurring.py
+++ b/fieldservice_recurring/models/fsm_recurring.py
@@ -173,7 +173,7 @@ class FSMRecurringOrder(models.Model):
             thru_date = request_thru_date
         # use variables to calulate and return the rruleset object
         ruleset = self.fsm_frequency_set_id._get_rruleset(
-            dtstart=next_date, until=thru_date
+            dtstart=next_date, until=thru_date, tz=self.location_id.tz
         )
         return ruleset
 
@@ -272,7 +272,7 @@ class FSMRecurringOrder(models.Model):
             if rec.max_orders > 0:
                 orders_in_30 = rec.fsm_order_count
                 orders_in_30 += rec.fsm_frequency_set_id._get_rruleset(
-                    until=expire_date
+                    until=expire_date, tz=rec.location_id.tz
                 ).count()
                 if orders_in_30 >= rec.max_orders:
                     to_renew += rec


### PR DESCRIPTION
Use location_id timezone prioritarily if set when generating fsm orders for a location