### PR TITLE
[FIX] fieldervice_activity

### DIFF
--- a/fieldservice_activity/models/fsm_order.py
+++ b/fieldservice_activity/models/fsm_order.py
@@ -52,6 +52,5 @@ class FSMOrder(models.Model):
                     )
                     % activity_id.name
                 )
-        for activity_id in self.activity_ids:
-            activity_id.done = True
+        activity_ids.action_done()
         return res

--- a/fieldservice_activity/models/fsm_order.py
+++ b/fieldservice_activity/models/fsm_order.py
@@ -52,5 +52,5 @@ class FSMOrder(models.Model):
                     )
                     % activity_id.name
                 )
-        activity_ids.action_done()
+        self.activity_ids.action_done()
         return res


### PR DESCRIPTION
Fixing call to set linked activity to done on fsm.order.
Previous odoo version used field done. It is now done through the action_done()