### PR TITLE
[15.0][FIX] fieldservice: FSM Category parent

### DIFF
--- a/fieldservice/models/fsm_category.py
+++ b/fieldservice/models/fsm_category.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018 - TODAY, Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class FSMCategory(models.Model):
@@ -23,10 +23,11 @@ class FSMCategory(models.Model):
 
     _sql_constraints = [("name_uniq", "unique (name)", "Category name already exists!")]
 
+    @api.depends("name", "parent_id.full_name")
     def _compute_full_name(self):
         for record in self:
             record.full_name = (
-                record.parent_id.full_name + "/" + record.name
+                record.parent_id.full_name + " / " + record.name
                 if record.parent_id
                 else record.name
             )

--- a/fieldservice/models/fsm_category.py
+++ b/fieldservice/models/fsm_category.py
@@ -7,11 +7,17 @@ from odoo import api, fields, models
 class FSMCategory(models.Model):
     _name = "fsm.category"
     _description = "Field Service Worker Category"
+    _parent_name = "parent_id"
+    _parent_store = True
+    _rec_name = "full_name"
+    _order = "full_name"
 
     name = fields.Char(required="True")
-    parent_id = fields.Many2one("fsm.category", string="Parent")
+    full_name = fields.Char(compute="_compute_full_name", store=True)
+    parent_id = fields.Many2one("fsm.category", string="Parent", index=True)
+    parent_path = fields.Char(index=True)
+    child_id = fields.One2many("fsm.category", "parent_id", "Child Categories")
     color = fields.Integer("Color Index", default=10)
-    full_name = fields.Char(compute="_compute_full_name")
     description = fields.Char()
     company_id = fields.Many2one(
         "res.company",

--- a/fieldservice/tests/test_fsm_category.py
+++ b/fieldservice/tests/test_fsm_category.py
@@ -16,5 +16,5 @@ class TestFsmCategory(test_fsm_order.TestFSMOrder):
         self.assertEqual(self.fsm_category_a.full_name, self.fsm_category_a.name)
         self.assertEqual(
             self.fsm_category_b.full_name,
-            "%s/%s" % (self.fsm_category_a.name, self.fsm_category_b.name),
+            "%s / %s" % (self.fsm_category_a.name, self.fsm_category_b.name),
         )

--- a/fieldservice/tests/test_fsm_category.py
+++ b/fieldservice/tests/test_fsm_category.py
@@ -1,15 +1,21 @@
 # Copyright (C) 2019 Brian McMaster <brian@mcmpest.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.exceptions import UserError
+
 from . import test_fsm_order
 
 
 class TestFsmCategory(test_fsm_order.TestFSMOrder):
     def setUp(self):
         super().setUp()
-        self.fsm_category_a = self.env["fsm.category"].create({"name": "Category A"})
-        self.fsm_category_b = self.env["fsm.category"].create(
+        fsm_category = self.env["fsm.category"]
+        self.fsm_category_a = fsm_category.create({"name": "Category A"})
+        self.fsm_category_b = fsm_category.create(
             {"name": "Category B", "parent_id": self.fsm_category_a.id}
+        )
+        self.fsm_category_c = fsm_category.create(
+            {"name": "Category C", "parent_id": self.fsm_category_b.id}
         )
 
     def test_fsm_order_category(self):
@@ -18,3 +24,8 @@ class TestFsmCategory(test_fsm_order.TestFSMOrder):
             self.fsm_category_b.full_name,
             "%s / %s" % (self.fsm_category_a.name, self.fsm_category_b.name),
         )
+
+    def test_fsm_category_recursion(self):
+        self.assertTrue(self.fsm_category_c._check_recursion())
+        with self.assertRaises(UserError):
+            self.fsm_category_a.write({"parent_id": self.fsm_category_c.id})


### PR DESCRIPTION
This PR aims to improve the parent/child features of FSM Category.  


- Added decorator to `_compute_full_name` method for dependent fields
- Added keys and fields required to optimize searching and reading categories
- Prevent recursive FSM Categories