### PR TITLE
[14.0][FIX] fieldservice: Domain attribute on fsm.equipment

### DIFF
--- a/fieldservice/models/fsm_equipment.py
+++ b/fieldservice/models/fsm_equipment.py
@@ -26,6 +26,7 @@ class FSMEquipment(models.Model):
         "fsm.stage",
         string="Stage",
         tracking=True,
+        domain="[('stage_type', '=', 'equipment')]",
         index=True,
         copy=False,
         group_expand="_read_group_stage_ids",

--- a/fieldservice/views/fsm_equipment.xml
+++ b/fieldservice/views/fsm_equipment.xml
@@ -83,11 +83,7 @@
                         type="object"
                         groups="fieldservice.group_fsm_dispatcher"
                     />
-                    <field
-                        name="stage_id"
-                        widget="statusbar"
-                        domain="[('stage_type', '=', 'equipment')]"
-                    />
+                    <field name="stage_id" widget="statusbar" />
                 </header>
                 <sheet>
                     <label for="name" class="oe_edit_only" />


### PR DESCRIPTION
All of the stages in `fsm.stage` model are appearing when you open the children equipment wizard.

To prevent this I removed the domain attribute from the xml file and added it to the `stage_id` field attributes.