### PR TITLE
[14.0][FIX] fieldservice: display avatar in kanban tasks

### DIFF
--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -298,7 +298,7 @@
                                     </div>
                                     <div class="oe_kanban_bottom_right">
                                         <img
-                                            t-att-src="kanban_image('person', 'image_small', record.person_id.name)"
+                                            t-att-src="kanban_image('fsm.person', 'image_128', record.person_id.raw_value)"
                                             t-att-title="record.person_id.name"
                                             t-att-alt="record.person_id.name"
                                             width="24"


### PR DESCRIPTION
Hi,
I was having the following issue:
the small avatars in the `fieldservice` kanban never displayed the image of the worker assigned to the task.


I made a small fix to address that.
Now the avatars seem to be displayed correctly.

EDIT: grammar, title