### PR TITLE
[14.0][FIX] fieldservice_maintenance: correct dates in equipment maintenance tab

### DIFF
--- a/fieldservice_maintenance/models/maintenance_request.py
+++ b/fieldservice_maintenance/models/maintenance_request.py
@@ -36,7 +36,11 @@ class MaintenanceRequest(models.Model):
                     "location_id": fsm_equipment.current_location_id.id,
                     "request_id": request.id,
                     "description": request.description,
+                    "request_early": request.schedule_date,
+                    "scheduled_date_start": request.schedule_date,
+                    "priority": request.priority,
                 }
             )
+
             request.fsm_order_id = fsm_order_id
         return request


### PR DESCRIPTION
Hi,
I'm submitting a correction for `fieldservice_maintenance`

In the dictionary passed to the original `fsm_order` there were a few parameters missing. By passing them the dates shown in the Field Service Order page are now coherent with the request's

EDIT: fixed title