### PR TITLE
[14.0][IMP]fieldservice_activity: allow group_fsm_user_own to access fsm.order

### DIFF
--- a/fieldservice_activity/__manifest__.py
+++ b/fieldservice_activity/__manifest__.py
@@ -15,6 +15,7 @@
         "views/fsm_order.xml",
         "views/fsm_template.xml",
         "security/ir.model.access.csv",
+        "security/ir_rule.xml",
     ],
     "development_status": "Beta",
     "maintainers": ["max3903", "osi-scampbell"],

--- a/fieldservice_activity/security/ir.model.access.csv
+++ b/fieldservice_activity/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_fsm_activity_fsm_user,fsm.activity.user,model_fsm_activity,fieldservice.group_fsm_user,1,1,0,0
+access_fsm_activity_fsm_user,fsm.activity.user,model_fsm_activity,fieldservice.group_fsm_user_own,1,1,0,0
 access_fsm_activity_fsm_manager,fsm.activity.manager,model_fsm_activity,fieldservice.group_fsm_manager,1,1,1,1

--- a/fieldservice_activity/security/ir_rule.xml
+++ b/fieldservice_activity/security/ir_rule.xml
@@ -1,0 +1,17 @@
+<odoo>
+    <record id="fsm_activity_own_rule" model="ir.rule">
+        <field name="name">FSM Activities (only own orders)</field>
+        <field name="model_id" ref="model_fsm_activity" />
+        <field
+            name="domain_force"
+        >['|',('fsm_order_id.person_id.user_ids','=',user.id),('fsm_order_id.person_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('fieldservice.group_fsm_user_own'))]" />
+    </record>
+
+    <record id="fsm_activity_user" model="ir.rule">
+        <field name="name">FSM Order Activities</field>
+        <field name="model_id" ref="model_fsm_activity" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('fieldservice.group_fsm_user'))]" />
+    </record>
+</odoo>


### PR DESCRIPTION
Hello,

this PR fixes security groups on fieldservice_activity. Without it, users with `group_fsm_user_own` simply cannot access fsm_orders at all.

The same ir_rules as the base `fieldservice` modules have been replicated.