### PR TITLE
[14.0][IMP]fieldservice_activity: duplicate fsm.order activities

### DIFF
--- a/fieldservice_activity/models/fsm_activity.py
+++ b/fieldservice_activity/models/fsm_activity.py
@@ -31,6 +31,7 @@ class FSMActivity(models.Model):
         [("todo", "To Do"), ("done", "Completed"), ("cancel", "Cancelled")],
         "State",
         readonly=True,
+        copy=False,
         default="todo",
     )
 

--- a/fieldservice_activity/tests/test_fsm_activity.py
+++ b/fieldservice_activity/tests/test_fsm_activity.py
@@ -98,3 +98,17 @@ class TestFSMActivity(TransactionCase):
         self.assertNotEquals(
             self.fso.order_activity_ids.ids, self.fso.template_id.temp_activity_ids.ids
         )
+        # making sure that activities are correctly copied when assigning a template
+        test_order = self.Order.create(
+            {
+                "location_id": self.test_location.id,
+                "template_id": self.template.id,
+                "order_activity_ids": False,
+            }
+        )
+        self.assertNotEquals(
+            test_order.order_activity_ids.id, self.template.temp_activity_ids.id
+        )
+        self.assertEqual(
+            test_order.order_activity_ids.name, self.template.temp_activity_ids.name
+        )


### PR DESCRIPTION
1. When duplicating a FS Order, also duplicate related activities, but reset their state to "todo"
2. When creating a new fsm.order, only copy the activities from the template if none have been already added, do not blindly overwrite them.
3. Trigger the onchange function on an fsm.order's template_id to overwrite existing activities only when adding a template, do not empty out the activities when removing it.