### PR TITLE
[14.0][FIX] fieldservice_activity: Typos and formatting in strings

### DIFF
--- a/fieldservice_activity/models/fsm_activity.py
+++ b/fieldservice_activity/models/fsm_activity.py
@@ -14,7 +14,6 @@ class FSMActivity(models.Model):
         "Name", required=True, readonly=True, states={"todo": [("readonly", False)]}
     )
     required = fields.Boolean(
-        "Requireid",
         default=False,
         readonly=True,
         states={"todo": [("readonly", False)]},

--- a/fieldservice_activity/models/fsm_order.py
+++ b/fieldservice_activity/models/fsm_order.py
@@ -8,7 +8,9 @@ from odoo.exceptions import ValidationError
 class FSMOrder(models.Model):
     _inherit = "fsm.order"
 
-    order_activity_ids = fields.One2many("fsm.activity", "fsm_order_id", "Activites")
+    order_activity_ids = fields.One2many(
+        "fsm.activity", "fsm_order_id", "Order Activities"
+    )
 
     @api.onchange("template_id")
     def _onchange_template_id(self):
@@ -47,8 +49,8 @@ class FSMOrder(models.Model):
             if activity_id.required and activity_id.state == "todo":
                 raise ValidationError(
                     _(
-                        "You must complete activity '%s' before \
-                    completing this order."
+                        "You must complete activity '%s' before "
+                        "completing this order."
                     )
                     % activity_id.name
                 )


### PR DESCRIPTION
Minor fix for a couple of typos and the formatting of an error string

Note: just calling them "Activities" generates a warning

```
2023-01-04 14:04:52,557 20 WARNING devel odoo.addons.base.models.ir_model: Two fields (activity_ids, order_activity_ids) of fsm.order() have the same label: Activities. 
```

The string on the model matters little anyway, since it's not currently shown in the views