### PR TITLE
[14.0][FIX]fieldservice_recurring: fix security for group_fsm_user_own

### DIFF
--- a/fieldservice_recurring/views/fsm_order.xml
+++ b/fieldservice_recurring/views/fsm_order.xml
@@ -3,6 +3,10 @@
     <record id="view_fsm_order_form" model="ir.ui.view">
         <field name="model">fsm.order</field>
         <field name="inherit_id" ref="fieldservice.fsm_order_form" />
+        <field
+            name="groups_id"
+            eval="[(4, ref('fieldservice_recurring.group_fsm_recurring'))]"
+        />
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
                 <button

--- a/fieldservice_recurring/views/fsm_team.xml
+++ b/fieldservice_recurring/views/fsm_team.xml
@@ -9,6 +9,10 @@
     <record model="ir.ui.view" id="view_team_kanban_recurring">
         <field name="model">fsm.team</field>
         <field name="inherit_id" ref="fieldservice.view_team_kanban" />
+        <field
+            name="groups_id"
+            eval="[(4, ref('fieldservice_recurring.group_fsm_recurring'))]"
+        />
         <field name="arch" type="xml">
             <field name="name" position="after">
                 <field name="recurring_draft_count" />


### PR DESCRIPTION
Fixes to let users without access to recurring orders (most notably, `group_fsm_user_own` still access and use the fieldservice app without permission errors.