### PR TITLE
[14.0][FIX]fieldservice_geoengine: fsm_user_own can see maps

### DIFF
--- a/fieldservice_geoengine/security/res_groups.xml
+++ b/fieldservice_geoengine/security/res_groups.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <record id="fieldservice.group_fsm_user" model="res.groups">
+    <record id="fieldservice.group_fsm_user_own" model="res.groups">
         <field name="name">User</field>
         <field name="category_id" ref="fieldservice.fsm" />
         <field


### PR DESCRIPTION
The map cannot be viewed with just `fsm_user` permissions. Full `fsm_user_own` is required to do so.