### PR TITLE
[14.0][IMP] fielservice_geoengine: refactor of fieldservice_geoengine module

### DIFF
--- a/fieldservice/tests/test_fsm_order.py
+++ b/fieldservice/tests/test_fsm_order.py
@@ -45,7 +45,8 @@ class TestFSMOrder(TestFSMOrderBase):
             vals = {"request_early": fields.Datetime.today(), "priority": priority}
             vals = order._compute_request_late(vals)
             self.assertEqual(
-                vals["request_late"], order.request_early + timedelta(days=late_days)
+                vals["request_late"],
+                order.request_early + timedelta(days=late_days),
             )
         # Test scheduled_date_start is not automatically set
         self.assertEqual(

--- a/fieldservice_geoengine/__init__.py
+++ b/fieldservice_geoengine/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2018 - TODAY, Open Source Integrators
+# Copyright (C) 2023 - TODAY Pytech SRL
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models

--- a/fieldservice_geoengine/__manifest__.py
+++ b/fieldservice_geoengine/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2018 - TODAY, Open Source Integrators
+# Copyright (C) 2023 - TODAY Pytech SRL
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
@@ -7,10 +8,15 @@
     "license": "AGPL-3",
     "version": "14.0.1.0.0",
     "category": "Field Service",
-    "author": "Open Source Integrators, Odoo Community Association (OCA)",
+    "author": "Open Source Integrators, Odoo Community Association (OCA), Pytech SRL",
     "website": "https://github.com/OCA/field-service",
     "depends": ["base_geoengine", "fieldservice"],
-    "data": ["security/res_groups.xml", "views/fsm_team.xml", "views/fsm_order.xml"],
+    "data": [
+        "security/res_groups.xml",
+        "views/fsm_location.xml",
+        "views/fsm_team.xml",
+        "views/fsm_order.xml",
+    ],
     "development_status": "Beta",
     "maintainers": ["wolfhall", "max3903"],
 }

--- a/fieldservice_geoengine/models/fsm_location.py
+++ b/fieldservice_geoengine/models/fsm_location.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2018 Open Source Integrators
+# Copyright (C) 2023 - TODAY Pytech SRL
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
@@ -8,47 +9,29 @@ class FSMLocation(models.Model):
     _inherit = "fsm.location"
 
     # Geometry Field
-    shape = fields.GeoPoint("Coordinate")
+    shape = fields.GeoPoint("Coordinate", compute="_compute_shape", store=True)
+    stage_name = fields.Char(related="stage_id.name", string="Stage Name")
+    custom_color = fields.Char(related="stage_id.custom_color", string="Stage Color")
 
     @api.model
     def create(self, vals):
-        vals.update({"fsm_location": True})
         res = super(FSMLocation, self).create(vals)
-        lat = res.partner_id.partner_latitude
-        lng = res.partner_id.partner_longitude
-        if lat == 0.0 and lng == 0.0:
+        if not res.partner_latitude or not res.partner_longitude:
             res.geo_localize()
-        else:
-            point = fields.GeoPoint.from_latlon(
-                cr=self.env.cr, latitude=lat, longitude=lng
-            )
-            res.shape = point
         return res
 
     def geo_localize(self):
-        for loc in self:
-            if loc.partner_id:
-                loc.partner_id.geo_localize()
-            lat = loc.partner_latitude
-            lng = loc.partner_longitude
-            point = fields.GeoPoint.from_latlon(
-                cr=loc.env.cr, latitude=lat, longitude=lng
-            )
-            loc.shape = point
+        self.mapped("partner_id").geo_localize()
 
-    def _update_order_geometries(self):
+    @api.depends("partner_latitude", "partner_longitude")
+    def _compute_shape(self):
         for loc in self:
-            orders = loc.env["fsm.order"].search([("location_id", "=", loc.id)])
-            for order in orders:
-                order.create_geometry()
-
-    def write(self, vals):
-        res = super(FSMLocation, self).write(vals)
-        if ("partner_latitude" in vals) and ("partner_longitude" in vals):
-            self.shape = fields.GeoPoint.from_latlon(
-                cr=self.env.cr,
-                latitude=vals["partner_latitude"],
-                longitude=vals["partner_longitude"],
-            )
-            self._update_order_geometries()
-        return res
+            if loc.partner_latitude or loc.partner_longitude:
+                point = fields.GeoPoint.from_latlon(
+                    cr=loc.env.cr,
+                    latitude=loc.partner_latitude,
+                    longitude=loc.partner_longitude,
+                )
+                loc.shape = point
+            else:
+                loc.shape = False

--- a/fieldservice_geoengine/models/fsm_order.py
+++ b/fieldservice_geoengine/models/fsm_order.py
@@ -1,38 +1,14 @@
 # Copyright (C) 2018 Open Source Integrators
+# Copyright (C) 2023 - TODAY Pytech SRL
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class FSMOrder(models.Model):
     _inherit = "fsm.order"
 
-    # Geometry Field
-    shape = fields.GeoPoint("Coordinate")
-
-    @api.model
-    def create(self, vals):
-        res = super().create(vals)
-        res.create_geometry()
-        return res
-
-    @api.onchange("location_id")
-    def onchange_location_id(self):
-        res = super().onchange_location_id()
-        if self.location_id:
-            self.create_geometry()
-        return res
-
-    def create_geometry(self):
-        for order in self:
-            lat = order.location_id.partner_latitude
-            lng = order.location_id.partner_longitude
-            point = fields.GeoPoint.from_latlon(
-                cr=order.env.cr, latitude=lat, longitude=lng
-            )
-            order.shape = point
+    shape = fields.GeoPoint(related="location_id.shape", string="Coordinate")
 
     def geo_localize(self):
-        for order in self:
-            order.location_id.partner_id.geo_localize()
-            order.create_geometry()
+        self.mapped("location_id").geo_localize()

--- a/fieldservice_geoengine/readme/CONTRIBUTORS.rst
+++ b/fieldservice_geoengine/readme/CONTRIBUTORS.rst
@@ -1,8 +1,10 @@
-* Wolfgang Hall <whall@opensourceintegrators.com>
-* Maxime Chambreuil <mchambreuil@opensourceintegrators.com>
-* Steve Campbell <scampbell@opensourceintegrators.com>
-* Bhavesh Odedra <bodedra@opensourceintegrators.com>
-* Michael Allen <mallen@opensourceintegrators.com>
-* Sandip Mangukiya <smangukiya@opensourceintegrators.com>
+* Open Source Integrators
+    * Wolfgang Hall <whall@opensourceintegrators.com>
+    * Maxime Chambreuil <mchambreuil@opensourceintegrators.com>
+    * Steve Campbell <scampbell@opensourceintegrators.com>
+    * Bhavesh Odedra <bodedra@opensourceintegrators.com>
+    * Michael Allen <mallen@opensourceintegrators.com>
+    * Sandip Mangukiya <smangukiya@opensourceintegrators.com>
+    * Jevin Dement <jdement@opensourceintegrators.com>
 * Murtuza Saleh <murtuza.saleh@serpentcs.com>
-* Jevin Dement <jdement@opensourceintegrators.com>
+* Sebastiano Picchi <sebastiano.picchi@pytech.it>

--- a/fieldservice_geoengine/tests/test_fsm_location.py
+++ b/fieldservice_geoengine/tests/test_fsm_location.py
@@ -1,52 +1,154 @@
 # Copyright (C) 2012 - TODAY, Open Source Integrators
+# Copyright (C) 2023 - TODAY Pytech SRL
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import SavepointCase
 
 
-class TestFsmLocation(TransactionCase):
-    def setUp(self):
-        super(TestFsmLocation, self).setUp()
-        self.fsm_location = self.env["fsm.location"]
-        self.location_partner_1 = self.env.ref("fieldservice.location_partner_1")
-        self.location_partner_2 = self.env.ref("fieldservice.location_partner_2")
-        self.test_loc_partner = self.env.ref("fieldservice.test_loc_partner")
-        self.location_partner_3 = self.env.ref("fieldservice.location_partner_3")
+class TestFsmLocation(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.FSMLocation = cls.env["fsm.location"]
+        cls.location_partner_1 = cls.env.ref("fieldservice.location_partner_1")
+        cls.location_partner_2 = cls.env.ref("fieldservice.location_partner_2")
+        cls.location_partner_3 = cls.env.ref("fieldservice.location_partner_3")
+        cls.test_loc_partner = cls.env.ref("fieldservice.test_loc_partner")
+        # delta value of 0.00001 was chosen according to OpenStreetMap's decimal precision table
+        # https://wiki.openstreetmap.org/wiki/Precision_of_coordinates#Conversion_to_decimal
+        # 5 decimals are necessary for precision of about a metre
+        cls.delta = 0.000_01
 
-    def test_fsm_location(self):
-        test_location = self.fsm_location.create(
+        cls.test_location = cls.FSMLocation.create(
             {
                 "name": "Test Location 2",
                 "phone": "123",
-                "email": "tl@email.com",
-                "partner_id": self.location_partner_1.id,
-                "owner_id": self.location_partner_2.id,
+                "email": "test@example.com",
+                "partner_id": cls.location_partner_1.id,
+                "owner_id": cls.location_partner_2.id,
             }
         )
-        self.assertTrue(test_location.shape)
-        fsm_order = self.env["fsm.order"].create({"location_id": test_location.id})
-        test_location.write(
+
+    def test_fsm_location_creation(self):
+        test_partner = self.env["res.partner"].create(
+            {
+                "name": "Test partner",
+            }
+        )
+        # should not be localized yet
+        test_partner.write(
+            {
+                "street": "Rue des Bourlottes 9",
+                "zip": "1367",
+                "city": "Grand-Rosière",
+                "country_id": self.env.ref("base.be"),
+            }
+        )
+        self.assertFalse(self.location_partner_1.partner_latitude)
+        self.assertFalse(self.location_partner_1.partner_longitude)
+        # should be localized after assigning a partner to the location
+        test_location_1 = self.FSMLocation.create(
+            {
+                "name": "Test Location 2",
+                "phone": "123",
+                "email": "test@example.com",
+                "partner_id": test_partner.id,
+                "owner_id": self.location_partner_1.id,
+            }
+        )
+        self.assertTrue(test_location_1.partner_latitude)
+        self.assertTrue(test_location_1.partner_longitude)
+        self.assertAlmostEqual(
+            test_location_1.partner_latitude, 50.629981, delta=self.delta
+        )
+        self.assertAlmostEqual(
+            test_location_1.partner_longitude, 4.863366, delta=self.delta
+        )
+        # direct creation and same exit data
+        partner_latitude = 1.0
+        partner_longitude = 2.0
+        test_location_2 = self.FSMLocation.create(
+            {
+                "name": "Test Location 2",
+                "phone": "123",
+                "email": "test@example.com",
+                "partner_id": self.location_partner_1.id,
+                "owner_id": self.location_partner_2.id,
+                "partner_latitude": partner_latitude,
+                "partner_longitude": partner_longitude,
+            }
+        )
+        self.assertTrue(test_location_2.shape)
+        self.assertAlmostEqual(
+            test_location_2.partner_latitude, partner_latitude, delta=self.delta
+        )
+        self.assertAlmostEqual(
+            test_location_2.partner_longitude, partner_longitude, delta=self.delta
+        )
+
+    def test_fsm_location_update(self):
+        # update both coordinates
+        self.test_location.write(
             {
                 "date_localization": fields.Datetime.today(),
                 "partner_latitude": 1.00,
                 "partner_longitude": 2.00,
             }
         )
-        self.assertTrue(test_location.partner_latitude)
-        self.assertTrue(test_location.partner_longitude)
-        self.assertTrue(test_location.shape)
-        fsm_order.geo_localize()
-
-        self.test_loc_partner.partner_latitude = 1.0
-        self.test_loc_partner.partner_longitude = 2.0
-        test_location1 = self.fsm_location.create(
+        self.assertTrue(self.test_location.partner_latitude)
+        self.assertTrue(self.test_location.partner_longitude)
+        self.assertTrue(self.test_location.shape)
+        # update a single coordinate (latitude)
+        new_latitude = 1.00
+        old_longitude = self.test_location.partner_longitude
+        self.test_location.write(
             {
-                "name": "Test Location 3",
-                "phone": "1234",
-                "email": "tl1@email.com",
-                "partner_id": self.test_loc_partner.id,
-                "owner_id": self.location_partner_3.id,
+                "partner_latitude": new_latitude,
             }
         )
-        self.assertTrue(test_location1.shape)
+        self.assertEqual(self.test_location.partner_latitude, new_latitude)
+        self.assertEqual(self.test_location.partner_longitude, old_longitude)
+        # update a single coordinate (longitude)
+        new_longitude = 7.00
+        old_latitude = self.test_location.partner_latitude
+        self.test_location.write(
+            {
+                "partner_longitude": new_longitude,
+            }
+        )
+        self.assertAlmostEqual(
+            self.test_location.partner_longitude, new_longitude, delta=self.delta
+        )
+        self.assertEqual(self.test_location.partner_latitude, old_latitude)
+
+    def test_fsm_location_association(self):
+        test_location = self.FSMLocation.create(
+            {
+                "name": "Test Location 2",
+                "phone": "123",
+                "email": "test@example.com",
+                "partner_id": self.location_partner_1.id,
+                "owner_id": self.location_partner_2.id,
+                "partner_latitude": 1.0,
+                "partner_longitude": 2.0,
+            }
+        )
+        fsm_order = self.env["fsm.order"].create({"location_id": test_location.id})
+        self.assertTrue(fsm_order.shape)
+        self.assertEqual(fsm_order.shape, test_location.shape)
+        # geolocalize method
+        fsm_order.geo_localize()
+        self.assertTrue(fsm_order.location_id)
+        # fsm_order should point to the same location
+        test_location.write(
+            {
+                "partner_latitude": 4.00,
+                "partner_longitude": 3.00,
+            }
+        )
+        self.assertEqual(fsm_order.shape, test_location.shape)
+        test_location.partner_latitude = False
+        self.assertTrue(test_location.shape)
+        test_location.partner_longitude = False
+        self.assertFalse(test_location.shape)

--- a/fieldservice_geoengine/views/fsm_location.xml
+++ b/fieldservice_geoengine/views/fsm_location.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="fsm_location_form_view" model="ir.ui.view">
+        <field name="name">fsm.location.form</field>
+        <field name="model">fsm.location</field>
+        <field name="inherit_id" ref="fieldservice.fsm_location_form_view" />
+        <field name="arch" type="xml">
+            <group id="get_locate" position="before">
+                <field name='shape' widget="geo_edit_map" />
+            </group>
+        </field>
+    </record>
+    <!-- GeoEngine views -->
+    <record id="ir_ui_view_fsm_location_map" model="ir.ui.view">
+        <field name="name">ir.ui.view.fsm.location.map</field>
+        <field name="arch" type="xml">
+            <geoengine>
+                <field name="name" select="1" />
+                <field name="display_name" />
+                <field name="phone" />
+                <field name="mobile" />
+                <field name="street" />
+                <field name="street2" />
+                <field name="city" />
+                <field name='zip' />
+                <field name='stage_name' />
+                <field name="shape" />
+                <field name="custom_color" />
+            </geoengine>
+        </field>
+        <field name="priority" eval="16" />
+        <field name="model">fsm.location</field>
+    </record>
+    <record id="loc_geoengine_vector_layer_fsm0" model="geoengine.vector.layer">
+        <field
+            name="geo_field_id"
+            ref="fieldservice_geoengine.field_fsm_location__shape"
+        />
+        <field name="name">FSM Location Point</field>
+        <field name="classification">unique</field>
+        <field name="sequence" eval="6" />
+        <field name="view_id" ref="ir_ui_view_fsm_location_map" />
+        <field name="geo_repr">colored</field>
+        <field name="nb_class" eval="1" />
+        <field
+            name="attribute_field_id"
+            ref="fieldservice_geoengine.field_fsm_location__stage_name"
+        />
+        <field name="begin_color">#0AFF68</field>
+    </record>
+    <record
+        id="loc_geoengine_vector_layer_fsmordertatecoloredcustom0"
+        model="geoengine.vector.layer"
+    >
+        <field
+            name="geo_field_id"
+            ref="fieldservice_geoengine.field_fsm_location__shape"
+        />
+        <field name="name">FSM Location State colored custom</field>
+        <field name="classification">custom</field>
+        <field name="sequence" eval="6" />
+        <field name="view_id" ref="ir_ui_view_fsm_location_map" />
+        <field name="geo_repr">colored</field>
+        <field name="nb_class" eval="1" />
+        <field
+            name="attribute_field_id"
+            ref="fieldservice_geoengine.field_fsm_location__custom_color"
+        />
+        <field name="begin_color">#FFFFFF</field>
+    </record>
+    <record id="loc_geoengine_raster_layer_osm" model="geoengine.raster.layer">
+        <field name="raster_type">osm</field>
+        <field name="name">Open Street Map</field>
+        <field name="view_id" ref="ir_ui_view_fsm_location_map" />
+        <field name="overlay" eval="0" />
+    </record>
+    <record id="loc_geoengine_raster_layer_basic0" model="geoengine.raster.layer">
+        <field name="raster_type">d_wms</field>
+        <field name="name">basic</field>
+        <field name="url">vmap0.tiles.osgeo.org/wms/vmap0</field>
+        <field name="view_id" ref="ir_ui_view_fsm_location_map" />
+        <field name="overlay" eval="1" />
+    </record>
+</odoo>

--- a/fieldservice_geoengine/views/fsm_order.xml
+++ b/fieldservice_geoengine/views/fsm_order.xml
@@ -50,7 +50,7 @@
                 <field name="custom_color" />
             </geoengine>
         </field>
-        <field eval="16" name="priority" />
+        <field name="priority" eval="16" />
         <field name="model">fsm.order</field>
     </record>
     <record id="geoengine_vector_layer_fsm0" model="geoengine.vector.layer">
@@ -60,10 +60,10 @@
         />
         <field name="name">FSM Order Point</field>
         <field name="classification">unique</field>
-        <field eval="6" name="sequence" />
+        <field name="sequence" eval="6" />
         <field name="view_id" ref="ir_ui_view_fsm_order_map" />
         <field name="geo_repr">colored</field>
-        <field eval="1" name="nb_class" />
+        <field name="nb_class" eval="1" />
         <field
             name="attribute_field_id"
             ref="fieldservice.field_fsm_order__stage_name"
@@ -80,10 +80,10 @@
         />
         <field name="name">FSM Order State colored custom</field>
         <field name="classification">custom</field>
-        <field eval="6" name="sequence" />
+        <field name="sequence" eval="6" />
         <field name="view_id" ref="ir_ui_view_fsm_order_map" />
         <field name="geo_repr">colored</field>
-        <field eval="1" name="nb_class" />
+        <field name="nb_class" eval="1" />
         <field
             name="attribute_field_id"
             ref="fieldservice.field_fsm_order__custom_color"
@@ -94,13 +94,13 @@
         <field name="raster_type">osm</field>
         <field name="name">Open Street Map</field>
         <field name="view_id" ref="ir_ui_view_fsm_order_map" />
-        <field eval="0" name="overlay" />
+        <field name="overlay" eval="0" />
     </record>
     <record id="geoengine_raster_layer_basic0" model="geoengine.raster.layer">
         <field name="raster_type">d_wms</field>
         <field name="name">basic</field>
         <field name="url">vmap0.tiles.osgeo.org/wms/vmap0</field>
         <field name="view_id" ref="ir_ui_view_fsm_order_map" />
-        <field eval="1" name="overlay" />
+        <field name="overlay" eval="1" />
     </record>
 </odoo>


### PR DESCRIPTION
WARNING: this PR was made some time ago. I fixed some things and had to rebase on the most recent commit.

I would like to propose some improvements to the fieldservice_geoengine module that we have been using and that we think could be helpful to the OCA field-service community.

fsm.order has been changed to be related to fsm.location with a many2one. This removes the need for a local shape, using an existing location instead. By doing so some methods are not needed anymore because they are in fsm.location already.

fsm.location has also been subject to changes:
 - some missing fields have been added.
 - shape attribute has been altered to a computed field in order to avoid unnecessary recalculations when it's requested. It's recomputed only when partner's latitude and/or longitude are changed.

The map view previously added by this module in the fsm_order form view has also been made available in fsm_location form view. This change was made so that a user does not have to generate an fsm_order in order to see the map with the fsm_location's position.

In addition to the previous changes the tests have been expanded for a broader control.