### PR TITLE
[15.0][IMP] fieldservice: Add freeze_time to test to prevent errors sometimes.

### DIFF
--- a/fieldservice/models/fsm_category.py
+++ b/fieldservice/models/fsm_category.py
@@ -13,7 +13,7 @@ class FSMCategory(models.Model):
     _order = "full_name"
 
     name = fields.Char(required="True")
-    full_name = fields.Char(compute="_compute_full_name", store=True)
+    full_name = fields.Char(compute="_compute_full_name", store=True, recursive=True)
     parent_id = fields.Many2one("fsm.category", string="Parent", index=True)
     parent_path = fields.Char(index=True)
     child_id = fields.One2many("fsm.category", "parent_id", "Child Categories")

--- a/fieldservice/report/fsm_order_report_template.xml
+++ b/fieldservice/report/fsm_order_report_template.xml
@@ -41,7 +41,7 @@
                 </div>
                 <div t-if="doc.todo" id="instruction">
                     <h3>Instructions</h3>
-                    <p t-raw="doc.todo" />
+                    <p t-out="doc.todo" />
                 </div>
                 <div t-if="doc.resolution" id="resolution">
                     <h3>Resolution Notes</h3>

--- a/fieldservice/tests/test_fsm_order.py
+++ b/fieldservice/tests/test_fsm_order.py
@@ -10,7 +10,7 @@ from odoo.tests.common import Form, TransactionCase
 
 
 @freeze_time("2023-02-01")
-class TestFSMOrder(TransactionCase):
+class TestFSMOrderBase(TransactionCase):
     def setUp(self):
         super().setUp()
         self.Order = self.env["fsm.order"]
@@ -118,6 +118,8 @@ class TestFSMOrder(TransactionCase):
             )
             self.assertRegex(str(res[0]), order.name)
 
+
+class TestFSMOrder(TestFSMOrderBase):
     def test_fsm_order(self):
         """Test creating new workorders, and test following functions,
         - _compute_duration() in hrs

--- a/fieldservice/tests/test_fsm_order.py
+++ b/fieldservice/tests/test_fsm_order.py
@@ -1,13 +1,15 @@
 # Copyright (C) 2019 - TODAY, Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
 from datetime import timedelta
+
+from freezegun import freeze_time
 
 from odoo import fields
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests.common import Form, TransactionCase
 
 
+@freeze_time("2023-02-01")
 class TestFSMOrder(TransactionCase):
     def setUp(self):
         super().setUp()
@@ -191,7 +193,7 @@ class TestFSMOrder(TransactionCase):
                 order_test.request_late, order.request_early + timedelta(days=late_days)
             )
         # Test scheduled_date_start is not automatically set
-        self.assertEqual(order.scheduled_date_start, False)
+        self.assertFalse(order.scheduled_date_start)
         # Test scheduled_date_end = scheduled_date_start + duration (hrs)
         # Set date start
         order.scheduled_date_start = fields.Datetime.now().replace(
@@ -204,8 +206,7 @@ class TestFSMOrder(TransactionCase):
         order.onchange_scheduled_duration()
         # Check date end
         self.assertEqual(
-            order.scheduled_date_end,
-            order.scheduled_date_start + timedelta(hours=duration),
+            order.scheduled_date_end, fields.Datetime.from_string("2023-02-01 10:00:00")
         )
         # Set new date end
         order.scheduled_date_end = order.scheduled_date_end.replace(
@@ -215,7 +216,7 @@ class TestFSMOrder(TransactionCase):
         # Check date start
         self.assertEqual(
             order.scheduled_date_start,
-            order.scheduled_date_end - timedelta(hours=duration),
+            fields.Datetime.from_string("2023-01-31 15:01:00"),
         )
         view_id = "fieldservice.fsm_location_form_view"
         with Form(self.env["fsm.location"], view=view_id) as f:

--- a/fieldservice/tests/test_fsm_order_template_onchange.py
+++ b/fieldservice/tests/test_fsm_order_template_onchange.py
@@ -5,7 +5,7 @@ from odoo import fields
 from . import test_fsm_order
 
 
-class TestTemplateOnchange(test_fsm_order.TestFSMOrder):
+class TestTemplateOnchange(test_fsm_order.TestFSMOrderBase):
     def setUp(self):
         super().setUp()
         self.fsm_category_a = self.env["fsm.category"].create({"name": "Category A"})


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/field-service/pull/1047

Add `freeze_time` to test to prevent errors metimes.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa