### PR TITLE
[14.0][IMP] fieldservice_sale: Only invoice invoiceable fsm order 

### DIFF
--- a/fieldservice_sale/models/sale_order_line.py
+++ b/fieldservice_sale/models/sale_order_line.py
@@ -62,6 +62,8 @@ class SaleOrderLine(models.Model):
         """
         invoiceable_stage_ids = self.env["fsm.stage"]._get_invoiceable_stage()
         dom = [
+            "|",
+            ("sale_line_id", "=", self.id),
             ("sale_id", "=", self.order_id.id),
             ("invoice_lines", "=", False),
         ]

--- a/fieldservice_sale/models/sale_order_line.py
+++ b/fieldservice_sale/models/sale_order_line.py
@@ -62,7 +62,7 @@ class SaleOrderLine(models.Model):
         """
         invoiceable_stage_ids = self.env["fsm.stage"]._get_invoiceable_stage()
         dom = [
-            ("sale_line_id", "=", self.id),
+            ("sale_id", "=", self.order_id.id),
             ("invoice_lines", "=", False),
         ]
         if invoiceable_stage_ids:


### PR DESCRIPTION
Splitting of @mourad-ehm #944 PR
Depends on:
- [x] #1051 

> Make link between invoice and fsm order compatible with invoice recurring order, add  _get_invoiceable_fsm_order & _get_invoiceable_fsm_order_domain