### PR TITLE
[15.0][FIX] fieldservice: replace type Text to Html in todo field

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -147,7 +147,7 @@ class FSMOrder(models.Model):
     scheduled_duration = fields.Float(help="Scheduled duration of the work in" " hours")
     scheduled_date_end = fields.Datetime(string="Scheduled End")
     sequence = fields.Integer(default=10)
-    todo = fields.Text(string="Instructions")
+    todo = fields.Html(string="Instructions")
 
     # Execution
     resolution = fields.Text()

--- a/fieldservice/tests/test_fsm_order_template_onchange.py
+++ b/fieldservice/tests/test_fsm_order_template_onchange.py
@@ -26,7 +26,7 @@ class TestTemplateOnchange(test_fsm_order.TestFSMOrderBase):
         self.fsm_template_1 = self.env["fsm.template"].create(
             {
                 "name": "Test FSM Template #1",
-                "instructions": "These are the instructions for Template #1",
+                "instructions": "<p>These are the instructions for Template #1</p>",
                 "category_ids": [(6, 0, categories)],
                 "duration": 2.25,
                 "type_id": self.fsm_type_a.id,
@@ -35,7 +35,7 @@ class TestTemplateOnchange(test_fsm_order.TestFSMOrderBase):
         self.fsm_template_2 = self.env["fsm.template"].create(
             {
                 "name": "Test FSM Template #1",
-                "instructions": "These are the instructions for Template #1",
+                "instructions": "<p>These are the instructions for Template #1</p>",
                 "category_ids": [(6, 0, categories)],
                 "duration": 2.25,
                 "team_id": self.fsm_team_a.id,
@@ -62,5 +62,5 @@ class TestTemplateOnchange(test_fsm_order.TestFSMOrderBase):
         )
         self.assertEqual(self.fso.scheduled_duration, self.fsm_template_1.duration)
         self.assertEqual(self.fso.type.id, self.fsm_template_1.type_id.id)
-        self.assertEqual(self.fso.todo, self.fsm_template_1.instructions)
+        self.assertEqual(str(self.fso.todo), self.fsm_template_1.instructions)
         self.assertEqual(self.fso2.team_id.id, self.fsm_team_a.id)

--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -128,7 +128,7 @@
                         </page>
                         <page string="Instructions" name="instructions_page">
                             <group string="Instructions" name="instructions_grp">
-                                <field name="todo" nolabel="1" widget="html" />
+                                <field name="todo" nolabel="1" />
                             </group>
                             <group
                                 string="Location Directions"


### PR DESCRIPTION
Due to the version change from 14.0 to 15.0, the t-raw was replaced by t-out, this field was not displayed correctly in the service orders report, an attempt was made to change the t-out to others such as t-esc or t- field. but it is not displayed correctly, then choose to change the type to html, since in all the views that are called this field the widget is added.

Before in runboat with Text field:
![imagen](https://user-images.githubusercontent.com/22427989/233007960-5e46459d-c13b-4f65-8346-8adcebfc22d9.png)

After with Html field:
![imagen](https://user-images.githubusercontent.com/22427989/233007519-59f9941e-f531-401a-85ed-26faa25ba0d6.png)
