### PR TITLE
[16.0][FIX] fieldservice_stock: make inventory location editable

### DIFF
--- a/fieldservice_stock/models/fsm_location.py
+++ b/fieldservice_stock/models/fsm_location.py
@@ -12,6 +12,7 @@ class FSMLocation(models.Model):
         string="Inventory Location",
         compute="_compute_inventory_location_id",
         store=True,
+        readonly=False,
         required=True,
         recursive=True,
         default=lambda self: self.env.ref("stock.stock_location_customers"),


### PR DESCRIPTION
Inventory location field for FSM location moved to compute stored field in v16, but became readonly. This fix it.