### PR TITLE
[14.0][FIX] fieldservice_account_analytic: Write correct value for customer_id

### DIFF
--- a/fieldservice_account_analytic/models/fsm_order.py
+++ b/fieldservice_account_analytic/models/fsm_order.py
@@ -56,8 +56,7 @@ class FSMOrder(models.Model):
             self.location_id = self.customer_id.service_location_id
 
     def write(self, vals):
-        res = super(FSMOrder, self).write(vals)
         for order in self:
-            if "customer_id" not in vals and order.customer_id is False:
-                order.customer_id = order.location_id.customer_id.id
-        return res
+            if "customer_id" not in vals and not order.customer_id:
+                vals.update({"customer_id": order.location_id.customer_id.id})
+        return super(FSMOrder, self).write(vals)

--- a/fieldservice_sale/models/fsm_order.py
+++ b/fieldservice_sale/models/fsm_order.py
@@ -20,3 +20,15 @@ class FSMOrder(models.Model):
             "context": {"create": False},
             "name": _("Sales Orders"),
         }
+
+    def write(self, vals):
+        for order in self:
+            if "customer_id" not in vals and not order.customer_id:
+                vals.update({"customer_id": order.sale_id.partner_id.id})
+        return super(FSMOrder, self).write(vals)
+
+    def create(self, vals):
+        sale_id = self.env["sale.order"].browse(vals.get("sale_id"))
+        if sale_id:
+            vals["customer_id"] = sale_id.partner_id.id
+        return super(FSMOrder, self).create(vals)

--- a/fieldservice_sale/models/fsm_order.py
+++ b/fieldservice_sale/models/fsm_order.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Brian McMaster
 # Copyright (C) 2019 Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 
 
 class FSMOrder(models.Model):
@@ -27,6 +27,7 @@ class FSMOrder(models.Model):
                 vals.update({"customer_id": order.sale_id.partner_id.id})
         return super(FSMOrder, self).write(vals)
 
+    @api.model
     def create(self, vals):
         sale_id = self.env["sale.order"].browse(vals.get("sale_id"))
         if sale_id:

--- a/fieldservice_stock_account/tests/test_fsm_stock_account.py
+++ b/fieldservice_stock_account/tests/test_fsm_stock_account.py
@@ -3,6 +3,7 @@
 
 import datetime
 
+from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
 
@@ -76,6 +77,7 @@ class FSMStockAccountCase(TransactionCase):
         SR_2.action_confirm()
         fsm_order2.account_no_invoice()
         fsm_order2.bill_to = "contact"
-        fsm_order2.account_no_invoice()
+        with self.assertRaises(ValidationError):
+            fsm_order2.account_no_invoice()
         fsm_order2.customer_id = self.test_partner.id
         fsm_order2.account_no_invoice()

--- a/fieldservice_stock_account/tests/test_fsm_stock_account.py
+++ b/fieldservice_stock_account/tests/test_fsm_stock_account.py
@@ -3,7 +3,6 @@
 
 import datetime
 
-from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
 
@@ -77,7 +76,6 @@ class FSMStockAccountCase(TransactionCase):
         SR_2.action_confirm()
         fsm_order2.account_no_invoice()
         fsm_order2.bill_to = "contact"
-        with self.assertRaises(UserError):
-            fsm_order2.account_no_invoice()
+        fsm_order2.account_no_invoice()
         fsm_order2.customer_id = self.test_partner.id
         fsm_order2.account_no_invoice()


### PR DESCRIPTION
The value for customer_id was written with the wrong value as the `order.location_id.customer_id` points to a different value than the sale order that generates the fsm_order

Also, it was not written at creation