### PR TITLE
[14.0] fieldservice_geoengine: fix test to new values from api

### DIFF
--- a/fieldservice_geoengine/tests/test_fsm_location.py
+++ b/fieldservice_geoengine/tests/test_fsm_location.py
@@ -60,10 +60,10 @@ class TestFsmLocation(SavepointCase):
         self.assertTrue(test_location_1.partner_latitude)
         self.assertTrue(test_location_1.partner_longitude)
         self.assertAlmostEqual(
-            test_location_1.partner_latitude, 50.629981, delta=self.delta
+            test_location_1.partner_latitude, 50.629850, delta=self.delta
         )
         self.assertAlmostEqual(
-            test_location_1.partner_longitude, 4.863366, delta=self.delta
+            test_location_1.partner_longitude, 4.863860, delta=self.delta
         )
         # direct creation and same exit data
         partner_latitude = 1.0


### PR DESCRIPTION
this test fails, because the answer of the api has changed it's not good to fix it that way, but it's quicker. see discussion on https://github.com/OCA/field-service/pull/1039/files