### PR TITLE
[FIX] fieldservice_crm: order smart button

### DIFF
--- a/fieldservice_crm/views/crm_lead.xml
+++ b/fieldservice_crm/views/crm_lead.xml
@@ -16,7 +16,7 @@
                     name="%(fieldservice.action_fsm_dash_order)d"
                     icon="fa-truck"
                     groups="fieldservice.group_fsm_user"
-                    context="{'search_default_opportunity_id': active_id,
+                    context="{'search_default_opportunity_id': id,
                               'default_location_id': fsm_location_id}"
                 >
                     <field


### PR DESCRIPTION
Steps to reproduce:
CRM App > Sales menu > Teams
Choose a team and click to open  Pipeline > open any lead

Click the FSM Orders smart button.

Actual behavior:
The active_id in context is from the sales team model rather than the lead model.  Therefore we have the wrong lead id  in the search context and you cannot see correct leads or make a new lead with the correct lead_id

Expected behavior:
The search view has context for current lead id, not the sales team id