### PR TITLE
[14.0][FIX] fieldservice_recurring: Default team

### DIFF
--- a/fieldservice_recurring/models/fsm_recurring.py
+++ b/fieldservice_recurring/models/fsm_recurring.py
@@ -15,7 +15,11 @@ class FSMRecurringOrder(models.Model):
     _inherit = ["mail.thread", "mail.activity.mixin"]
 
     def _default_team_id(self):
-        return self.env.ref("fieldservice.fsm_team_default")
+        return self.env["fsm.team"].search(
+            [["company_id", "in", (self.env.company.id, False)]],
+            limit=1,
+            order="sequence",
+        )
 
     name = fields.Char(
         string="Name",


### PR DESCRIPTION
support multicompany

before this pr, you get errors when creating a recurring order with a company different than `ref(fsm_team_default).company_id`