### PR TITLE
[16.0][FIX] fieldservice: allow to quick create a fsm.stage

### DIFF
--- a/fieldservice/models/fsm_stage.py
+++ b/fieldservice/models/fsm_stage.py
@@ -49,6 +49,7 @@ class FSMStage(models.Model):
         ],
         "Type",
         required=True,
+        default="order",
     )
     company_id = fields.Many2one(
         "res.company",

--- a/fieldservice/readme/CONTRIBUTORS.rst
+++ b/fieldservice/readme/CONTRIBUTORS.rst
@@ -15,3 +15,4 @@
 
   * Víctor Martínez
 * Nils Coenen <nils.coenen@nico-solutions.de>
+* Alex Comba <alex.comba@agilebg.com>


### PR DESCRIPTION
Steps to reproduce the behavior:

1. open dashboard Field Service Orders
2. click "Add a Column" in the kanban view
3. type a new stage name

Current behavior:

```
2023-08-29 10:48:02,995 73200 ERROR test-fieldservice odoo.sql_db: bad query: INSERT INTO "fsm_stage" ("id", "create_uid", "create_date", "write_uid", "write_date", "active", "custom_color", "name", "sequence") VALUES (nextval('fsm_stage_id_seq'), 2, (now() at time zone 'UTC'), 2, (now() at time zone 'UTC'), true, '#FFFFFF', 'test', 1) RETURNING id
ERROR: null value in column "stage_type" violates not-null constraint
DETAIL:  Failing row contains (13, t, test, 1, null, null, null, null, #FFFFFF, null, null, null, 2, 2023-08-29 10:48:02.988337, 2, 2023-08-29 10:48:02.988337).

2023-08-29 10:48:03,000 73200 WARNING test-fieldservice odoo.http: The operation cannot be completed:
- Create/update: a mandatory field is not set.
- Delete: another model requires the record being deleted. If possible, archive it instead.

Model: Field Service Stage (fsm.stage), Field: Type (stage_type)
```

Expected behavior:

the fsm.stage is created with type 'order' by default.