### PR TITLE
Avoid call to _recompute_tax_lines() after account.move create()

### DIFF
--- a/fieldservice_isp_account/models/fsm_order.py
+++ b/fieldservice_isp_account/models/fsm_order.py
@@ -129,8 +129,7 @@ class FSMOrder(models.Model):
 
     def create_bills(self):
         vals = self.prepare_bills()
-        bill = self.env["account.move"].sudo().create(vals)
-        bill._recompute_tax_lines()
+        self.env["account.move"].sudo().create(vals)
 
     def account_confirm(self):
         for order in self:
@@ -246,7 +245,6 @@ class FSMOrder(models.Model):
         invoice_vals = self.account_prepare_invoice()
         invoice = self.env["account.move"].sudo().create(invoice_vals)
 
-        invoice._recompute_tax_lines()
         self.account_stage = "invoiced"
         return invoice
 


### PR DESCRIPTION
The call to _AccountMove._recompute_tax_lines()_ in _create_bills()_ and __account_create_invoice()_ methods can lead to 'Cannot create unbalanced journal entry.' errors when trying to generate the invoice from the _FSM Orders Accounting_ tab.

The same invoice can be created without problems from a SO with the same content (same product ids, same quantities, etc..).

## How to reproduce

Environment: Odoo 14 CE clean install with demo data + fieldservice_isp_account

Prerequisites:
1. From _Invoicing / Configuration / Settings_ set _Rounding Method_ equal to _Round Globally_.
2. From _Invoicing / Configuration / Settings_ enable _Cash Roundings_.
3. From _Invoicing / Configuration / Cash Roundings_ create a new _account.cash.rounding_ with _Rounding Precision_ equal to _0.05_, _Rounding Strategy_ equal to _Modify tax amount_ and _Rounding Method_ equal to _HALF-UP_.
4. From _Invoicing / Configuration / Taxes_ create an _account.tax with Amount_ equal to _7.7000%_ and _Tax Computation_ equal to _Percentage of Price_.
5. From _Sales / Products / Products_ create a new _product.template_ with _Sales Price_ equal to _$ 99.80_ and _Customer Taxes_ equal to _7.7_ (the tax just created). Let's call it _Test Rounding_.
6. From _Field Service / Master Data / Locations_ click on _Test Location_ and under the tab _Accounting_ set any valid _Analytic Account_ (make the field not empty).

Actual bug:
1. From _Field Service / Order_ click on _Create_.
2. Set _Location_ as _Test Location_.
3. Under _Accounting_ add a new line under _Employee Timesheets_: set _Employee_ equal to _Anita Oliver_ (any value will be fine), _Time Type_ equal to _Test Rounding_ and _Duration_ equal to _08:00_.
4. Save the Order.
5. Complete the Order.
6. Under the _Order_ _Accounting_ tab click on _Confirm_.
7. Under the _Order_ _Accounting_ tab click on _Create Invoice_.

Now a User Error will be displayed, with text:

> `Cannot create unbalanced journal entry. Ids: [21]
> Differences debit - credit: [0.02]`

The root cause is that the account.move.line created are not balanced:

```
self.line_ids.mapped('debit')
[0.0, 0.0, 859.9]
self.line_ids.mapped('credit')
[798.4, 61.48, 0.0]
```

By removing the call to _recompute_tax_lines() the invoice is created without raising any exception and the account.move.line are correct.


## Considerations

By looking at Odoo standard addons I don't see any case of account.move create() followed by _recompute_tax_lines(). That private method is (rightfully) called only internally by AccountMove methods.

Is there a reason behind the inclusion of this line of code? My concern is that this particular change could fix this particular problem by introducing some other bug I'm not aware of.
