### PR TITLE
[16.0] [FIX] fieldservice : error printing report

### DIFF
--- a/fieldservice/i18n/es.po
+++ b/fieldservice/i18n/es.po
@@ -44,7 +44,7 @@ msgstr "# de Ubicaciones Propias"
 #. module: fieldservice
 #: model:ir.actions.report,print_report_name:fieldservice.action_report_fsm_order
 msgid "'Service Order - %s' % (object.name)"
-msgstr "Orden de servicio - %s' % (object.name)"
+msgstr "'Orden de servicio - %s' % (object.name)"
 
 #. module: fieldservice
 #: model:ir.model.fields,help:fieldservice.field_fsm_location__type


### PR DESCRIPTION
When printing an fsm order report in Spanish, the print_report_name translation fails due to a missing single quote.

