### PR TITLE
[16.0] [FIX] fieldservice: FSM Person Calendar Filter

### DIFF
--- a/fieldservice/models/fsm_person_calendar_filter.py
+++ b/fieldservice/models/fsm_person_calendar_filter.py
@@ -16,13 +16,14 @@ class FSMPersonCalendarFilter(models.Model):
         default=lambda self: self.env.user,
         ondelete="cascade",
     )
-    fsm_person_id = fields.Many2one("fsm.person", "FSM Worker", required=True)
+    person_id = fields.Many2one("fsm.person", "FSM Worker", required=True)
     active = fields.Boolean(default=True)
+    person_checked = fields.Boolean(default=True)
 
     _sql_constraints = [
         (
             "user_id_fsm_person_id_unique",
-            "UNIQUE(user_id,fsm_person_id)",
+            "UNIQUE(user_id,person_id)",
             "You cannot have the same worker twice.",
         )
     ]

--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -466,7 +466,8 @@
                 <field
                     name="person_id"
                     write_model="fsm.person.calendar.filter"
-                    write_field="fsm_person_id"
+                    write_field="person_id"
+                    filter_field="person_checked"
                     avatar_field="image_128"
                 />
                 <field name="team_id" filters="1" />


### PR DESCRIPTION
Steps to reproduce:

Go to FSM Order calendar view
Attempt to add a new FSM Person in the filter.

Receive Error:
![Screenshot from 2024-01-05 12-11-46](https://github.com/OCA/field-service/assets/25710115/376e1c1a-2d96-448f-8be7-af9eec10b123)


- Changed `fsm_person_id` to `person_id` to fix error
- Added support for saving which person is checked with `person_checked`
