### PR TITLE
[16.0][FIX] fieldservice_sale: Fix sale order line create method

### DIFF
--- a/fieldservice_sale/__manifest__.py
+++ b/fieldservice_sale/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Field Service - Sales",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.1.1",
     "summary": "Sell field services.",
     "category": "Field Service",
     "author": "Open Source Integrators, Odoo Community Association (OCA)",

--- a/fieldservice_sale/__manifest__.py
+++ b/fieldservice_sale/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Field Service - Sales",
-    "version": "16.0.1.1.1",
+    "version": "16.0.1.1.0",
     "summary": "Sell field services.",
     "category": "Field Service",
     "author": "Open Source Integrators, Odoo Community Association (OCA)",

--- a/fieldservice_sale/models/sale_order_line.py
+++ b/fieldservice_sale/models/sale_order_line.py
@@ -51,7 +51,7 @@ class SaleOrderLine(models.Model):
         for line in lines:
             if line.state == "sale":
                 line.order_id._field_service_generation()
-        return line
+        return lines
 
     def _prepare_invoice_line(self, **optional_values):
         res = super()._prepare_invoice_line(**optional_values)


### PR DESCRIPTION
This PR fixes a bug with the sales order line create method in the fieldservice_sale module to account for cases when the method is triggered without any sales order lines that are created, e.g. on some expense reports. This correction is in line with other `create()` methods and all sales order lines that are created should be returned, not just the last.

Currently, the method throws an undefined variable error for `line` if there are no sales order lines created and only returns the last sales order line if there are any created.