### PR TITLE
[16.0][FIX] fieldservice: Fix HTML field declaration

### DIFF
--- a/fieldservice/models/fsm_location.py
+++ b/fieldservice/models/fsm_location.py
@@ -12,7 +12,7 @@ class FSMLocation(models.Model):
     _description = "Field Service Location"
     _stage_type = "location"
 
-    direction = fields.Char()
+    direction = fields.Html()
     partner_id = fields.Many2one(
         "res.partner",
         string="Related Partner",
@@ -54,7 +54,7 @@ class FSMLocation(models.Model):
 
     calendar_id = fields.Many2one("resource.calendar", string="Office Hours")
     fsm_parent_id = fields.Many2one("fsm.location", string="Parent", index=True)
-    notes = fields.Text(string="Location Notes")
+    notes = fields.Html(string="Location Notes")
     person_ids = fields.One2many("fsm.location.person", "location_id", string="Workers")
     contact_count = fields.Integer(
         string="Contacts Count", compute="_compute_contact_ids"

--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -112,7 +112,7 @@ class FSMOrder(models.Model):
     location_id = fields.Many2one(
         "fsm.location", string="Location", index=True, required=True
     )
-    location_directions = fields.Char()
+    location_directions = fields.Html()
     request_early = fields.Datetime(
         string="Earliest Request Date", default=datetime.now()
     )
@@ -176,7 +176,7 @@ class FSMOrder(models.Model):
     scheduled_duration = fields.Float(help="Scheduled duration of the work in" " hours")
     scheduled_date_end = fields.Datetime(string="Scheduled End")
     sequence = fields.Integer(default=10)
-    todo = fields.Text(string="Instructions")
+    todo = fields.Html(string="Instructions")
 
     # Execution
     resolution = fields.Text()

--- a/fieldservice/models/fsm_template.py
+++ b/fieldservice/models/fsm_template.py
@@ -9,7 +9,7 @@ class FSMTemplate(models.Model):
     _description = "Field Service Order Template"
 
     name = fields.Char(required=True)
-    instructions = fields.Text()
+    instructions = fields.Html()
     category_ids = fields.Many2many("fsm.category", string="Categories")
     duration = fields.Float(help="Default duration in hours")
     company_id = fields.Many2one(

--- a/fieldservice/readme/CONTRIBUTORS.rst
+++ b/fieldservice/readme/CONTRIBUTORS.rst
@@ -16,3 +16,7 @@
   * Víctor Martínez
 * Nils Coenen <nils.coenen@nico-solutions.de>
 * Alex Comba <alex.comba@agilebg.com>
+
+* `XCG Consulting <https://xcg-consulting.fr>`_:
+
+  * Houzéfa Abbasbhay

--- a/fieldservice/views/fsm_location.xml
+++ b/fieldservice/views/fsm_location.xml
@@ -164,16 +164,11 @@
                         </group>
                     </group>
                     <group string="General Notes">
-                        <field name="notes" nolabel="1" colspan="2" widget="html" />
+                        <field name="notes" nolabel="1" colspan="2" />
                     </group>
                     <notebook>
                         <page string="Directions" name="directions">
-                            <field
-                                name="direction"
-                                nolabel="1"
-                                colspan="2"
-                                widget="html"
-                            />
+                            <field name="direction" nolabel="1" colspan="2" />
                         </page>
                         <page
                             string="Territory"

--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -147,12 +147,7 @@
                         </page>
                         <page string="Instructions" name="instructions_page">
                             <group string="Instructions" name="instructions_grp">
-                                <field
-                                    name="todo"
-                                    nolabel="1"
-                                    colspan="2"
-                                    widget="html"
-                                />
+                                <field name="todo" nolabel="1" colspan="2" />
                             </group>
                             <group
                                 string="Location Directions"
@@ -162,7 +157,6 @@
                                     name="location_directions"
                                     nolabel="1"
                                     colspan="2"
-                                    widget="html"
                                 />
                             </group>
                         </page>

--- a/fieldservice/views/fsm_template.xml
+++ b/fieldservice/views/fsm_template.xml
@@ -54,7 +54,7 @@
                     </group>
                     <notebook>
                         <page string="Instructions" name="instructions_page">
-                            <field name="instructions" nolabel="1" widget="html" />
+                            <field name="instructions" nolabel="1" />
                         </page>
                     </notebook>
                 </sheet>


### PR DESCRIPTION
Type mix-up was provoking infinite loops when navigating out of form views with "next" arrow buttons.

Fixes #1161.

I checked an upgrade, works fine - Odoo correctly updates SQL field types, no need to add a migration script.