### PR TITLE
[16.0][FIX] fieldservice: Fix manual location creation

### DIFF
--- a/fieldservice/views/fsm_location.xml
+++ b/fieldservice/views/fsm_location.xml
@@ -106,6 +106,7 @@
                                 name="partner_id"
                                 groups="base.group_no_one"
                                 readonly="1"
+                                required="0"
                             />
                             <field name="owner_id" />
                             <field


### PR DESCRIPTION
Read-only+required partner field shown in debug mode was preventing manual creation in debug mode or with OCA module base_technical_features.