### PR TITLE
[16.0][FIX] fieldservice: Fix location partner type

### DIFF
--- a/fieldservice/models/fsm_location.py
+++ b/fieldservice/models/fsm_location.py
@@ -70,10 +70,12 @@ class FSMLocation(models.Model):
     )
 
     @api.model_create_multi
-    def create(self, vals):
-        res = super().create(vals)
-        res.write({"fsm_location": True})
-        return res
+    def create(self, vals_list):
+        for vals in vals_list:
+            vals.update({"fsm_location": True, "type": "fsm_location"})
+        return super(FSMLocation, self.with_context(creating_fsm_location=True)).create(
+            vals_list
+        )
 
     @api.depends("partner_id.name", "fsm_parent_id.complete_name", "ref")
     def _compute_complete_name(self):

--- a/fieldservice/tests/test_fsm_location.py
+++ b/fieldservice/tests/test_fsm_location.py
@@ -50,6 +50,12 @@ class FSMLocation(TransactionCase):
         ]:
             self.assertEqual(location[x], self.test_location[x])
 
+        # Check partner defaults.
+        self.assertTrue(location.fsm_location)
+        self.assertFalse(location.fsm_person)
+        self.assertFalse(location.is_company)
+        self.assertEqual(location.type, "fsm_location")
+
         # Test initial stage
         self.assertEqual(
             location.stage_id, self.env.ref("fieldservice.location_stage_1")

--- a/fieldservice/tests/test_fsm_wizard.py
+++ b/fieldservice/tests/test_fsm_wizard.py
@@ -60,14 +60,15 @@ class FSMWizard(TransactionCase):
         # convert test_partner to FSM Location
         self.Wizard.action_convert_location(self.test_partner)
 
-        # check if there is a new FSM Location with name 'Test Partner'
-        self.wiz_location = self.env["fsm.location"].search(
-            [("name", "=", "Test Partner")]
-        )
-
-        # check if 'Test Partner' creation successful and fields copied over
-        self.assertEqual(self.test_location.phone, self.wiz_location.phone)
-        self.assertEqual(self.test_location.email, self.wiz_location.email)
+        # Check new service location.
+        new_location = self.env["fsm.location"].search([("name", "=", "Test Partner")])
+        self.assertNotEqual(new_location, self.test_location)
+        self.assertTrue(new_location.fsm_location)
+        self.assertFalse(new_location.fsm_person)
+        self.assertFalse(new_location.is_company)
+        self.assertEqual(new_location.type, "fsm_location")
+        self.assertEqual(self.test_location.phone, new_location.phone)
+        self.assertEqual(self.test_location.email, new_location.email)
 
     def test_convert_person(self):
         # convert test_partner to FSM Person

--- a/fieldservice/wizard/fsm_wizard.py
+++ b/fieldservice/wizard/fsm_wizard.py
@@ -34,7 +34,7 @@ class FSMWizard(models.TransientModel):
         fl_model = self.env["fsm.location"]
         if fl_model.search_count([("partner_id", "=", partner.id)]) == 0:
             fl_model.create(self._prepare_fsm_location(partner))
-            partner.write({"fsm_location": True})
+            partner.write({"fsm_location": True, "type": "fsm_location"})
             self.action_other_address(partner)
         else:
             raise UserError(


### PR DESCRIPTION
Service locations `fsm.location` create a partner `res.partner` through inheritance.

Before this change, partners could be explicitely typed "fsm_location" when adding them within children of an existing partner, which in turn would automatically create service locations on top of them.

But creating a service location by hand would not set that type on the partner created through inheritance. After this change, all partners built from service locations are typed the same.

Fixes #1128.