### PR TITLE
[16.0][IMP] fieldservice: Set location parent to owner

### DIFF
--- a/fieldservice/models/fsm_location.py
+++ b/fieldservice/models/fsm_location.py
@@ -72,7 +72,10 @@ class FSMLocation(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
+            # By default, create inherited partner as typed child of the location owner.
             vals.update({"fsm_location": True, "type": "fsm_location"})
+            if not vals.get("partner_id"):  # Don't change parent of existing partners.
+                vals["parent_id"] = vals.get("owner_id")
         return super(FSMLocation, self.with_context(creating_fsm_location=True)).create(
             vals_list
         )

--- a/fieldservice/tests/test_fsm_location.py
+++ b/fieldservice/tests/test_fsm_location.py
@@ -54,6 +54,8 @@ class FSMLocation(TransactionCase):
         self.assertTrue(location.fsm_location)
         self.assertFalse(location.fsm_person)
         self.assertFalse(location.is_company)
+        self.assertEqual(location.parent_id, self.test_loc_partner)
+        self.assertNotEqual(location.partner_id, self.test_loc_partner)
         self.assertEqual(location.type, "fsm_location")
 
         # Test initial stage

--- a/fieldservice/wizard/fsm_wizard.py
+++ b/fieldservice/wizard/fsm_wizard.py
@@ -28,7 +28,7 @@ class FSMWizard(models.TransientModel):
         return {"type": "ir.actions.act_window_close"}
 
     def _prepare_fsm_location(self, partner):
-        return {"partner_id": partner.id, "owner_id": partner.id}
+        return {"partner_id": partner.id, "owner_id": (partner.parent_id or partner).id}
 
     def action_convert_location(self, partner):
         fl_model = self.env["fsm.location"]


### PR DESCRIPTION
Before this change, service location partners (created through
inheritance) were typed "fsm_location" but did not always have a parent.

When adding them within children of an existing partner, they of course
did have a parent, but not the other way around: they had no parents
when created, through inheritance, upon service location creation.

After this change, service location partners are by default children of
the service location owner partner.

This is only done through defaults but not as related fields, which
would break too much. Therefore, existing partners are not impacted by
this change; only new ones created when creating a service location.

See #1128.

This PR is a follow-up on #1164 where partner types got made more consistent.