### PR TITLE
[14.0][FIX] fieldservice_recurring: company required on recurring

### DIFF
--- a/fieldservice_recurring/models/fsm_recurring.py
+++ b/fieldservice_recurring/models/fsm_recurring.py
@@ -70,7 +70,7 @@ class FSMRecurringOrder(models.Model):
         help="This is the order template that will be recurring",
     )
     company_id = fields.Many2one(
-        "res.company", "Company", default=lambda self: self.env.user.company_id
+        "res.company", "Company", default=lambda self: self.env.company, required=True
     )
     fsm_order_ids = fields.One2many(
         "fsm.order", "fsm_recurring_id", string="Orders", copy=False


### PR DESCRIPTION
Company is required, to match FS Order. Order generation fails if company is not set