### PR TITLE
[14.0] [FIX] fieldservice_activity: activities string warning

### DIFF
--- a/fieldservice_activity/models/fsm_order.py
+++ b/fieldservice_activity/models/fsm_order.py
@@ -11,7 +11,7 @@ class FSMOrder(models.Model):
     order_activity_ids = fields.One2many(
         comodel_name="fsm.activity",
         inverse_name="fsm_order_id",
-        string="Activities",
+        string="Order Activities",
         copy=True,
     )
 


### PR DESCRIPTION
This PR address the following warning in the logs while installing the module:

```
WARNING devel odoo.addons.base.models.ir_model: Two fields (order_activity_ids, activity_ids) of fsm.order() have the same label: Activities.
```