### PR TITLE
[14.0][FIX]fieldservice_stage_validation: validate only with explicit fields

### DIFF
--- a/fieldservice_stage_validation/models/validate_utils.py
+++ b/fieldservice_stage_validation/models/validate_utils.py
@@ -9,6 +9,8 @@ def validate_stage_fields(records):
     for rec in records:
         stage = rec.stage_id
         field_ids = stage.validate_field_ids
+        if not field_ids:
+            continue
         field_names = [x.name for x in field_ids]
         values = rec.read(field_names)
 


### PR DESCRIPTION
Previously the line
```py
values = rec.read(field_names)
```
evaluated all the fields when `field_names` was an empty list.

This resulted in unwanted checks.