### PR TITLE
[16.0][FIX] fieldservice_geoengine: Get extent when open the map

### DIFF
--- a/fieldservice_geoengine/views/fsm_order.xml
+++ b/fieldservice_geoengine/views/fsm_order.xml
@@ -79,6 +79,7 @@
         <field name="sequence" eval="6" />
         <field name="view_id" ref="ir_ui_view_fsm_order_map" />
         <field name="geo_repr">colored</field>
+        <field name="active_on_startup">True</field>
         <field name="nb_class" eval="1" />
         <field
             name="attribute_field_id"


### PR DESCRIPTION
When click to open the map the orders throws an error related to getSource.
With this fix can open the map with a default vector layer opened by default.

Fixed Module 

cc https://github.com/APSL 156339

@miquelalzanillas @lbarry-apsl @javierobcn @mpascuall please review
