### PR TITLE
[16.0] [FIX] fieldservice: schedule date methods

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -346,7 +346,7 @@ class FSMOrder(models.Model):
             date_to_with_delta = fields.Datetime.from_string(
                 self.scheduled_date_end
             ) - timedelta(hours=self.scheduled_duration)
-            self.date_start = str(date_to_with_delta)
+            self.scheduled_date_start = str(date_to_with_delta)
 
     @api.onchange("scheduled_date_start", "scheduled_duration")
     def onchange_scheduled_duration(self):

--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -317,7 +317,7 @@ class FSMOrder(models.Model):
                     self.scheduled_date_start != vals.get("scheduled_date_start", False)
                 )
             ):
-                hours = vals.get("scheduled_duration", False)
+                hours = vals.get("scheduled_duration", self.scheduled_duration)
                 start_date_val = vals.get(
                     "scheduled_date_start", self.scheduled_date_start
                 )


### PR DESCRIPTION
Two separate, but similar bugs related to schedule dates.

1. Prior to this fix If scheduled_date_end is updated, it would set date_start.  The correct field is scheduled_date_start
2. On order, update the scheduled_date_start, but do not update duration. Save record and scheduled_date_end was overwritten assuming a 0 duration