### PR TITLE
[16.0][IMP] fieldservice_calendar: Sync description

### DIFF
--- a/fieldservice_calendar/models/calendar.py
+++ b/fieldservice_calendar/models/calendar.py
@@ -15,38 +15,32 @@ class Meeting(models.Model):
 
     def _update_fsm_order_date(self):
         self.ensure_one()
-        if self._context.get("recurse_order_calendar"):
-            # avoid recursion
-            return
         to_apply = {}
         to_apply["scheduled_date_start"] = self.start
         to_apply["scheduled_duration"] = self.duration
-        self.fsm_order_id.with_context(recurse_order_calendar=True).write(to_apply)
+        self.fsm_order_id.write(to_apply)
 
     def _update_fsm_assigned(self):
         # update back fsm_order when an attenndee is member of a team
         self.ensure_one()
-        if self._context.get("recurse_order_calendar"):
-            # avoid recursion
-            return
-        person_id = None
-        for partner in self.partner_ids:
-            if partner.fsm_person:
-                person_id = (
-                    self.env["fsm.person"]
-                    .search([["partner_id", "=", partner.id]], limit=1)
-                    .id
-                )
-                break
-        self.fsm_order_id.with_context(recurse_order_calendar=True).write(
-            {"person_id": person_id}
-        )
+        for partner in self.partner_ids.filtered("fsm_person"):
+            self.fsm_order_id.person_id = self.env["fsm.person"].search(
+                [("partner_id", "=", partner.id)], limit=1
+            )
+            break
 
     def write(self, values):
         res = super().write(values)
-        if self.fsm_order_id:
-            if "start" in values or "duration" in values:
-                self._update_fsm_order_date()
-            if "partner_ids" in values:
-                self._update_fsm_assigned()
+        if values.keys() & {
+            "start",
+            "duration",
+            "partner_ids",
+        } and not self.env.context.get("recurse_order_calendar"):
+            for event in self.filtered("fsm_order_id").with_context(
+                recurse_order_calendar=True
+            ):
+                if "start" in values or "duration" in values:
+                    event._update_fsm_order_date()
+                if "partner_ids" in values:
+                    event._update_fsm_assigned()
         return res

--- a/fieldservice_calendar/readme/CONTRIBUTORS.rst
+++ b/fieldservice_calendar/readme/CONTRIBUTORS.rst
@@ -1,2 +1,5 @@
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
 * Freni Patel <fpatel@opensourceintegrators.com>
+* `XCG Consulting <https://xcg-consulting.fr>`_:
+
+  * Houzéfa Abbasbhay

--- a/fieldservice_calendar/tests/test_fsm_calendar.py
+++ b/fieldservice_calendar/tests/test_fsm_calendar.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import Form, TransactionCase
 
 
 class TestFSMOrder(TransactionCase):
@@ -18,25 +18,15 @@ class TestFSMOrder(TransactionCase):
         cls.person_id3 = cls.env.ref("fieldservice.person_3")
 
     def test_fsm_order_no_duration(self):
-        new = self.Order.create(
-            {
-                "location_id": self.test_location.id,
-                # no duration = no calendar
-            }
-        )
+        # not scheduled (no duration) = no calendar
+        new = self._create_fsm_order(schedule=False)
         evt = new.calendar_event_id
         self.assertFalse(evt.exists())
 
     def test_fsm_order_no_calendar_user(self):
         self.team.calendar_user_id = False
         # no calendar user_id  = no calendar event
-        new = self.Order.create(
-            {
-                "location_id": self.test_location.id,
-                "scheduled_date_start": fields.Datetime.today(),
-                "scheduled_duration": 2,
-            }
-        )
+        new = self._create_fsm_order(schedule=True)
         evt = new.calendar_event_id
         self.assertFalse(evt.exists())
         self.team.calendar_user_id = self.env.ref("base.partner_root").id
@@ -53,14 +43,7 @@ class TestFSMOrder(TransactionCase):
         self.assertFalse(evt.exists())
 
     def test_fsm_order_unlink(self):
-        # Create an Orders
-        new = self.Order.create(
-            {
-                "location_id": self.test_location.id,
-                "scheduled_date_start": fields.Datetime.today(),
-                "scheduled_duration": 2,
-            }
-        )
+        new = self._create_fsm_order(schedule=True)
         evt = new.calendar_event_id
         self.assertTrue(evt.exists())
 
@@ -72,14 +55,7 @@ class TestFSMOrder(TransactionCase):
         self.assertFalse(evt.exists())
 
     def test_fsm_order_ensure_attendee(self):
-        # Create an Orders
-        new = self.Order.create(
-            {
-                "location_id": self.test_location.id,
-                "scheduled_date_start": fields.Datetime.today(),
-                "scheduled_duration": 2,
-            }
-        )
+        new = self._create_fsm_order(schedule=True)
         evt = new.calendar_event_id
         self.assertTrue(
             len(evt.partner_ids) == 1,
@@ -94,3 +70,11 @@ class TestFSMOrder(TransactionCase):
         self.assertTrue(
             len(evt.partner_ids) == 2, "Not workers should be removed from attendees"
         )
+
+    def _create_fsm_order(self, schedule=False):
+        form = Form(self.Order)
+        form.location_id = self.test_location
+        if schedule:
+            form.scheduled_date_start = fields.Datetime.today()
+            form.scheduled_duration = 2
+        return form.save()

--- a/fieldservice_calendar/tests/test_fsm_calendar.py
+++ b/fieldservice_calendar/tests/test_fsm_calendar.py
@@ -71,6 +71,17 @@ class TestFSMOrder(TransactionCase):
             len(evt.partner_ids) == 2, "Not workers should be removed from attendees"
         )
 
+    def test_description_sync(self):
+        fsm_order = self._create_fsm_order(schedule=True)
+        event = fsm_order.calendar_event_id
+        self.assertEqual(event.description, "<p></p>")
+        with Form(fsm_order) as form:
+            form.description = "line 1\nline 2"
+        self.assertEqual(event.description, "<p>line 1<br>line 2</p>")
+        with Form(event) as form:
+            form.description = "<p>line 1<br>line 2<br>line 3</p>"
+        self.assertEqual(fsm_order.description, "line 1\nline 2\nline 3")
+
     def _create_fsm_order(self, schedule=False):
         form = Form(self.Order)
         form.location_id = self.test_location


### PR DESCRIPTION
This PR contains 2 commits: 1 to modernize code related to this field sync; 1 which adds description sync.

---

Propagate description updates between FSM order & calendar event.

1 is an HTML field, the other is not; we handle conversion.

Before this change, description was only propagated at calendar event creation, and without text➔html conversion.

---

To test:
* Field Service > Configuration > Settings: Enable "Manage Teams"
* Field Service > Configuration > Teams: Set a "Team's calendar"
* Create an FSM order, give it a scheduled date & duration
* Update FSM order description, observe updates in calendar event

FSM order with multiline description & schedule:
![Screenshot at 2024-07-12 15-30-33](https://github.com/user-attachments/assets/b0ec65d7-0787-4062-90c4-0ac3d6b5d252)

Calendar event with that multiline description (thanks to text➔html conversion):
![Screenshot at 2024-07-12 15-31-26](https://github.com/user-attachments/assets/78cbc8bd-7263-42b9-ae78-93fb83d5ca38)
