### PR TITLE
[FIX] fieldservice_recurring: Since Odoo 17, property fsm.recurring.fsm_recurring_template_id.states is no longer supported

### DIFF
--- a/fieldservice_recurring/models/fsm_recurring.py
+++ b/fieldservice_recurring/models/fsm_recurring.py
@@ -41,8 +41,6 @@ class FSMRecurringOrder(models.Model):
     fsm_recurring_template_id = fields.Many2one(
         "fsm.recurring.template",
         "Recurring Template",
-        readonly=True,
-        states={"draft": [("readonly", False)]},
     )
     location_id = fields.Many2one(
         "fsm.location", string="Location", index=True, required=True

--- a/fieldservice_recurring/views/fsm_recurring.xml
+++ b/fieldservice_recurring/views/fsm_recurring.xml
@@ -52,7 +52,10 @@
                     </div>
                     <group>
                         <group>
-                            <field name="fsm_recurring_template_id" />
+                            <field
+                                name="fsm_recurring_template_id"
+                                readonly="state != 'draft'"
+                            />
                             <field
                                 name="fsm_order_template_id"
                                 groups="fieldservice.group_fsm_template"


### PR DESCRIPTION
Fix the warning happening