### PR TITLE
[FIX] fieldservice_stage_validation: fix translation generation issue

### DIFF
--- a/fieldservice_stage_validation/i18n/es.po
+++ b/fieldservice_stage_validation/i18n/es.po
@@ -6,10 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-19 06:49+0000\n"
+"POT-Creation-Date: 2024-09-05 15:29+0000\n"
 "PO-Revision-Date: 2024-04-19 06:49+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -20,7 +21,9 @@ msgstr ""
 #: code:addons/fieldservice_stage_validation/models/validate_utils.py:0
 #, python-format
 msgid "Cannot move to stage %(stage_name)s until the %(name)s field is set."
-msgstr "No se puede mover al escenario %(stage_name)s hasta que se establezca el campo %(name)s."
+msgstr ""
+"No se puede mover al escenario %(stage_name)s hasta que se establezca el "
+"campo %(name)s."
 
 #. module: fieldservice_stage_validation
 #: model:ir.model,name:fieldservice_stage_validation.model_fsm_equipment
@@ -60,7 +63,8 @@ msgstr "Modelo para la Etapa"
 #. module: fieldservice_stage_validation
 #: model:ir.model.fields,help:fieldservice_stage_validation.field_fsm_stage__validate_field_ids
 msgid "Select fields which must be set on the document in this stage"
-msgstr "Seleccione los campos que se deben establecer en el documento en esta etapa"
+msgstr ""
+"Seleccione los campos que se deben establecer en el documento en esta etapa"
 
 #. module: fieldservice_stage_validation
 #: model:ir.model.fields,help:fieldservice_stage_validation.field_fsm_stage__stage_type_model_id

--- a/fieldservice_stage_validation/i18n/es_AR.po
+++ b/fieldservice_stage_validation/i18n/es_AR.po
@@ -4,8 +4,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-05 15:29+0000\n"
 "PO-Revision-Date: 2022-11-12 04:46+0000\n"
 "Last-Translator: Ignacio Buioli <ibuioli@gmail.com>\n"
 "Language-Team: none\n"
@@ -19,12 +20,11 @@ msgstr ""
 #. module: fieldservice_stage_validation
 #. odoo-python
 #: code:addons/fieldservice_stage_validation/models/validate_utils.py:0
-#, python-format
-msgid ""
-"Cannot move to stage \"%(stage_name)s\" until the \"%(name)s\" field is set."
+#, fuzzy, python-format
+msgid "Cannot move to stage %(stage_name)s until the %(name)s field is set."
 msgstr ""
-"No se puede mover al escenario \"%(stage_name)s\" hasta que se establezca el "
-"campo \"%(name)s\"."
+"No se puede mover al escenario %(stage_name)s hasta que se establezca el "
+"campo %(name)s."
 
 #. module: fieldservice_stage_validation
 #: model:ir.model,name:fieldservice_stage_validation.model_fsm_equipment
@@ -71,9 +71,3 @@ msgstr ""
 #: model:ir.model.fields,help:fieldservice_stage_validation.field_fsm_stage__stage_type_model_id
 msgid "Technical field to hold model type"
 msgstr "Campo técnico para mantener el tipo del modelo"
-
-#, python-format
-#~ msgid "Cannot move to stage \"%s\" until the \"%s\" field is set."
-#~ msgstr ""
-#~ "No se puede mover a la etapa \"%s\" hasta que se establezca el campo \"%s"
-#~ "\"."

--- a/fieldservice_stage_validation/i18n/fieldservice_stage_validation.pot
+++ b/fieldservice_stage_validation/i18n/fieldservice_stage_validation.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0\n"
+"Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-05 15:29+0000\n"
+"PO-Revision-Date: 2024-09-05 15:29+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"

--- a/fieldservice_stage_validation/i18n/fr_FR.po
+++ b/fieldservice_stage_validation/i18n/fr_FR.po
@@ -4,8 +4,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-05 15:29+0000\n"
 "PO-Revision-Date: 2021-05-20 10:48+0000\n"
 "Last-Translator: Sandrine (ACSONE) <sandrine.ravet@acsone.eu>\n"
 "Language-Team: none\n"
@@ -19,10 +20,10 @@ msgstr ""
 #. module: fieldservice_stage_validation
 #. odoo-python
 #: code:addons/fieldservice_stage_validation/models/validate_utils.py:0
-#, python-format
-msgid ""
-"Cannot move to stage \"%(stage_name)s\" until the \"%(name)s\" field is set."
+#, fuzzy, python-format
+msgid "Cannot move to stage %(stage_name)s until the %(name)s field is set."
 msgstr ""
+"Le champ %(stage_name)s doit être rempli pour passer à l'étape %(name)s."
 
 #. module: fieldservice_stage_validation
 #: model:ir.model,name:fieldservice_stage_validation.model_fsm_equipment
@@ -70,7 +71,3 @@ msgstr ""
 #: model:ir.model.fields,help:fieldservice_stage_validation.field_fsm_stage__stage_type_model_id
 msgid "Technical field to hold model type"
 msgstr "Champ technique pour contenir le type de modèle"
-
-#, python-format
-#~ msgid "Cannot move to stage \"%s\" until the \"%s\" field is set."
-#~ msgstr "Le champ \"%s\" doit être rempli pour passer à l'étape \"%s\"."

--- a/fieldservice_stage_validation/i18n/it.po
+++ b/fieldservice_stage_validation/i18n/it.po
@@ -4,8 +4,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-05 15:29+0000\n"
 "PO-Revision-Date: 2024-04-29 14:35+0000\n"
 "Last-Translator: mymage <stefano.consolaro@mymage.it>\n"
 "Language-Team: none\n"
@@ -19,12 +20,11 @@ msgstr ""
 #. module: fieldservice_stage_validation
 #. odoo-python
 #: code:addons/fieldservice_stage_validation/models/validate_utils.py:0
-#, python-format
-msgid ""
-"Cannot move to stage \"%(stage_name)s\" until the \"%(name)s\" field is set."
+#, fuzzy, python-format
+msgid "Cannot move to stage %(stage_name)s until the %(name)s field is set."
 msgstr ""
-"Non si può passare allo stato \"%(stage_name)s\" finché il campo \"%(name)s"
-"\" non è compilato."
+"Non si può passare allo stato %(stage_name)s finché il campo %(name)s non è "
+"compilato."
 
 #. module: fieldservice_stage_validation
 #: model:ir.model,name:fieldservice_stage_validation.model_fsm_equipment
@@ -71,9 +71,3 @@ msgstr ""
 #: model:ir.model.fields,help:fieldservice_stage_validation.field_fsm_stage__stage_type_model_id
 msgid "Technical field to hold model type"
 msgstr "Campo tecnico per memorizzare il tipo modello"
-
-#, python-format
-#~ msgid "Cannot move to stage \"%s\" until the \"%s\" field is set."
-#~ msgstr ""
-#~ "Non si può passare alla fase \"%s\" finché il campo \"%s\" non è "
-#~ "impostato."

--- a/fieldservice_stage_validation/i18n/pt_BR.po
+++ b/fieldservice_stage_validation/i18n/pt_BR.po
@@ -4,8 +4,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-05 15:29+0000\n"
 "PO-Revision-Date: 2023-08-11 23:13+0000\n"
 "Last-Translator: Adriano Prado <adrianojprado@gmail.com>\n"
 "Language-Team: none\n"
@@ -19,12 +20,11 @@ msgstr ""
 #. module: fieldservice_stage_validation
 #. odoo-python
 #: code:addons/fieldservice_stage_validation/models/validate_utils.py:0
-#, python-format
-msgid ""
-"Cannot move to stage \"%(stage_name)s\" until the \"%(name)s\" field is set."
+#, fuzzy, python-format
+msgid "Cannot move to stage %(stage_name)s until the %(name)s field is set."
 msgstr ""
-"Não é possível mover para o estágio \"%(stage_name)s\" até que o campo "
-"\"%(name)s\" seja definido."
+"Não é possível mover para o estágio %(stage_name)s até que o campo %(name)s "
+"seja definido."
 
 #. module: fieldservice_stage_validation
 #: model:ir.model,name:fieldservice_stage_validation.model_fsm_equipment

--- a/fieldservice_stage_validation/i18n/pt_PT.po
+++ b/fieldservice_stage_validation/i18n/pt_PT.po
@@ -4,8 +4,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 12.0\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-05 15:29+0000\n"
 "PO-Revision-Date: 2020-07-02 00:19+0000\n"
 "Last-Translator: Daniel Reis <dgreis@sapo.pt>\n"
 "Language-Team: none\n"
@@ -19,10 +20,11 @@ msgstr ""
 #. module: fieldservice_stage_validation
 #. odoo-python
 #: code:addons/fieldservice_stage_validation/models/validate_utils.py:0
-#, python-format
-msgid ""
-"Cannot move to stage \"%(stage_name)s\" until the \"%(name)s\" field is set."
+#, fuzzy, python-format
+msgid "Cannot move to stage %(stage_name)s until the %(name)s field is set."
 msgstr ""
+"N??o pode mudar para etapa %(stage_name)s enquanto o campo %(name)s n??o for "
+"definido."
 
 #. module: fieldservice_stage_validation
 #: model:ir.model,name:fieldservice_stage_validation.model_fsm_equipment
@@ -69,9 +71,3 @@ msgstr ""
 #: model:ir.model.fields,help:fieldservice_stage_validation.field_fsm_stage__stage_type_model_id
 msgid "Technical field to hold model type"
 msgstr "Campo t??cnico para o tipo de modelo"
-
-#, python-format
-#~ msgid "Cannot move to stage \"%s\" until the \"%s\" field is set."
-#~ msgstr ""
-#~ "N??o pode mudar para etapa \"%s\" enquanto o campo \"%s\" n??o for "
-#~ "definido."

--- a/fieldservice_stage_validation/i18n/tr.po
+++ b/fieldservice_stage_validation/i18n/tr.po
@@ -4,8 +4,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-05 15:29+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: tr\n"
@@ -18,8 +19,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/fieldservice_stage_validation/models/validate_utils.py:0
 #, python-format
-msgid ""
-"Cannot move to stage \"%(stage_name)s\" until the \"%(name)s\" field is set."
+msgid "Cannot move to stage %(stage_name)s until the %(name)s field is set."
 msgstr ""
 
 #. module: fieldservice_stage_validation


### PR DESCRIPTION
Though translations are generated automatically we have an issue of non applied translations after regeneration (probably).
So, we're fixing this manually.
Manually tested in UI.

Now:

![now](https://github.com/user-attachments/assets/77d61bdd-977c-4507-afa0-9a1960e5a829)

After:

![error_in_french](https://github.com/user-attachments/assets/b0900bd7-8bb0-4e47-8db9-c1d954dc09eb)

