### PR TITLE
[FIX] fieldservice_stage_server_action: run server action on stage change

### DIFF
--- a/fieldservice_stage_server_action/models/__init__.py
+++ b/fieldservice_stage_server_action/models/__init__.py
@@ -2,3 +2,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import fsm_stage
+from . import fsm_order

--- a/fieldservice_stage_server_action/models/fsm_order.py
+++ b/fieldservice_stage_server_action/models/fsm_order.py
@@ -1,0 +1,31 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class FSMOrder(models.Model):
+    _inherit = "fsm.order"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        orders = super().create(vals_list)
+        orders._run_stage_server_action()
+        return orders
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "stage_id" in vals:
+            self._run_stage_server_action()
+        return res
+
+    def _run_stage_server_action(self):
+        for order in self:
+            action_id = order.stage_id.action_id
+            if not action_id:
+                continue
+            ctx = {
+                "active_model": self._name,
+                "active_id": order.id,
+            }
+            action_id.with_context(**ctx).run()

--- a/fieldservice_stage_server_action/tests/__init__.py
+++ b/fieldservice_stage_server_action/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_fsm_order_run_action

--- a/fieldservice_stage_server_action/tests/test_fsm_order_run_action.py
+++ b/fieldservice_stage_server_action/tests/test_fsm_order_run_action.py
@@ -1,0 +1,40 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import RecordCapturer, TransactionCase
+
+
+class TestFSMOrderRunAction(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Order = cls.env["fsm.order"]
+        cls.Tag = cls.env["fsm.tag"]
+        cls.test_location = cls.env.ref("fieldservice.test_location")
+        cls.stage1 = cls.env.ref("fieldservice.fsm_stage_completed")
+        cls.stage2 = cls.env.ref("fieldservice.fsm_stage_cancelled")
+        cls.location_1 = cls.env.ref("fieldservice.location_1")
+        cls.create_action = cls.env["ir.actions.server"].create(
+            {
+                "model_id": cls.env["ir.model"]._get_id("fsm.tag"),
+                "crud_model_id": cls.env["ir.model"]._get_id("fsm.tag"),
+                "name": "Create new tag",
+                "value": "New test tag",
+                "state": "object_create",
+            }
+        )
+        cls.stage2.action_id = cls.create_action
+
+    def test_fsm_order_run_action(self):
+        order = self.Order.create(
+            {
+                "location_id": self.test_location.id,
+                "stage_id": self.stage1.id,
+            }
+        )
+        self.assertFalse(self.Tag.search([("name", "=", "New test tag")]).exists())
+        with RecordCapturer(self.Tag, []) as capture:
+            order.write({"stage_id": self.stage2.id})
+        tag = capture.records
+        self.assertEqual(1, len(tag))
+        self.assertEqual("New test tag", tag.name)


### PR DESCRIPTION
Though the module is supposed to run a server action when `fsm.order` is changed, in fact it's not.
This PR fixes issue and introduce at least simple test.