### PR TITLE
[FIX] fieldservice_account_analytic: automatically fill Contact in FSM Order

### DIFF
--- a/fieldservice_account_analytic/README.rst
+++ b/fieldservice_account_analytic/README.rst
@@ -75,6 +75,7 @@ Contributors
 * Michael Allen <mallen@opensourceintegrators.com>
 * Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 * Brian McMaster <brian@mcmpest.com>
+* Alex Comba <alex.comba@agilebg.com>
 
 Other credits
 ~~~~~~~~~~~~~

--- a/fieldservice_account_analytic/models/fsm_order.py
+++ b/fieldservice_account_analytic/models/fsm_order.py
@@ -58,6 +58,6 @@ class FSMOrder(models.Model):
     def write(self, vals):
         res = super(FSMOrder, self).write(vals)
         for order in self:
-            if "customer_id" not in vals and order.customer_id is False:
+            if "customer_id" not in vals and not order.customer_id:
                 order.customer_id = order.location_id.customer_id.id
         return res

--- a/fieldservice_account_analytic/readme/CONTRIBUTORS.rst
+++ b/fieldservice_account_analytic/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Michael Allen <mallen@opensourceintegrators.com>
 * Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 * Brian McMaster <brian@mcmpest.com>
+* Alex Comba <alex.comba@agilebg.com>

--- a/fieldservice_account_analytic/static/description/index.html
+++ b/fieldservice_account_analytic/static/description/index.html
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils: https://docutils.sourceforge.io/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Field Service - Analytic Accounting</title>
 <style type="text/css">
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 7952 2016-07-26 18:15:59Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
 
-See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
+See http://docutils.sf.net/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
 */
 
@@ -423,6 +422,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Michael Allen &lt;<a class="reference external" href="mailto:mallen&#64;opensourceintegrators.com">mallen&#64;opensourceintegrators.com</a>&gt;</li>
 <li>Serpent Consulting Services Pvt. Ltd. &lt;<a class="reference external" href="mailto:support&#64;serpentcs.com">support&#64;serpentcs.com</a>&gt;</li>
 <li>Brian McMaster &lt;<a class="reference external" href="mailto:brian&#64;mcmpest.com">brian&#64;mcmpest.com</a>&gt;</li>
+<li>Alex Comba &lt;<a class="reference external" href="mailto:alex.comba&#64;agilebg.com">alex.comba&#64;agilebg.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="other-credits">

--- a/fieldservice_stock_account/tests/test_fsm_stock_account.py
+++ b/fieldservice_stock_account/tests/test_fsm_stock_account.py
@@ -3,7 +3,6 @@
 
 import datetime
 
-from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
 
@@ -77,7 +76,5 @@ class FSMStockAccountCase(TransactionCase):
         SR_2.action_confirm()
         fsm_order2.account_no_invoice()
         fsm_order2.bill_to = "contact"
-        with self.assertRaises(UserError):
-            fsm_order2.account_no_invoice()
-        fsm_order2.customer_id = self.test_partner.id
+        self.assertEqual(fsm_order2.customer_id, fsm_order2.location_id.customer_id)
         fsm_order2.account_no_invoice()


### PR DESCRIPTION
Start by saying that the logical behind it is not clear to me, during a debug session I noticed the following problem.

## To Reproduce

Steps to reproduce the behavior:
1. create a FSM order
2. set `location_id` field
3. edit the FSM order and save it

**Expected behavior**
Contact is automatically filled with that one of the Location.

**Additional context**
In debug we have:

```
> "customer_id" not in vals and order.customer_id is False
> False

> "customer_id" not in vals and not order.customer_id
> True
```
