### PR TITLE
[FIX] fieldservice: order check for holiday

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -414,6 +414,7 @@ class FSMOrder(models.Model):
                 [
                     ("date_from", ">=", rec.scheduled_date_start),
                     ("date_to", "<=", rec.scheduled_date_end),
+                    ("resource_id", "=", False),
                 ]
             )
             if holidays:


### PR DESCRIPTION
**Issue:**
With the Time Off application also installed, time off requests for any employee create a `resource.calendar.leave` record associated to that employee's resource.  In `fsm.order` there is a constraint on `scheduled_date_start` to check for a public holiday.  Users will incorrectly receive Validation error if user tries to assign a scheduled date start to an order that is same date as the time off of a random employee.