### PR TITLE
[17.0][FIX] fieldservice: buttons under stage_id cond. not displayed

### DIFF
--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -8,6 +8,7 @@
                 <header>
                     <field name="is_button" invisible="1" />
                     <field name="team_id" invisible="1" />
+                    <field name="is_closed" invisible="1" />
                     <button
                         id="action_complete"
                         name="action_complete"
@@ -15,7 +16,7 @@
                         class="oe_highlight"
                         type="object"
                         groups="fieldservice.group_fsm_user"
-                        invisible="stage_id.is_closed"
+                        invisible="is_closed"
                     />
                     <button
                         id="action_cancel"
@@ -23,7 +24,7 @@
                         string="Cancel Order"
                         type="object"
                         groups="fieldservice.group_fsm_dispatcher"
-                        invisible="stage_id.is_closed"
+                        invisible="is_closed"
                     />
                     <field
                         name="stage_id"


### PR DESCRIPTION
The buttons `Complete` and `Cancel Order` are not displayed.

![image](https://github.com/user-attachments/assets/4c06a7d6-f44a-46da-9379-0e4caeb83f4c)

Proposed fix:

Use `is_closed` directly instead to `stage_id.is_closed` on the `invisible` condition