### PR TITLE
[17.0] [FIX] fieldservice_stage_validation: missing rights to read `validate_field_ids`

### DIFF
--- a/fieldservice_stage_validation/__manifest__.py
+++ b/fieldservice_stage_validation/__manifest__.py
@@ -8,7 +8,10 @@
     "author": "Brian McMaster, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/field-service",
     "depends": ["fieldservice"],
-    "data": ["views/fsm_stage.xml"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/fsm_stage.xml",
+    ],
     "license": "AGPL-3",
     "development_status": "Beta",
     "maintainers": ["brian10048", "max3903"],

--- a/fieldservice_stage_validation/models/fsm_stage.py
+++ b/fieldservice_stage_validation/models/fsm_stage.py
@@ -11,7 +11,6 @@ class FSMStage(models.Model):
         string="Fields to Validate",
         help="Select fields which must be set on the document in this stage",
     )
-
     stage_type_model_id = fields.Many2one(
         "ir.model",
         compute="_compute_stage_model",

--- a/fieldservice_stage_validation/models/validate_utils.py
+++ b/fieldservice_stage_validation/models/validate_utils.py
@@ -8,7 +8,7 @@ from odoo.exceptions import ValidationError
 def validate_stage_fields(records):
     for rec in records:
         stage = rec.stage_id
-        field_ids = stage.validate_field_ids
+        field_ids = stage.sudo().validate_field_ids
         field_names = [x.name for x in field_ids]
         values = rec.read(field_names)
 

--- a/fieldservice_stage_validation/security/ir.model.access.csv
+++ b/fieldservice_stage_validation/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_ir_model_field,ir_model_fields fsm,base.model_ir_model_fields,fieldservice.group_fsm_user_own,1,0,0,0


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/5dc4cff60a557e14b08440c227423291c407899b, non-admin users don't have permissions to read `ir.model.fields`, causing a traceback when attempting to modify the FSM Stages