### PR TITLE
[17.0][FIX] fieldservice_recurring: Fix form view

### DIFF
--- a/fieldservice_recurring/views/fsm_recurring.xml
+++ b/fieldservice_recurring/views/fsm_recurring.xml
@@ -82,7 +82,7 @@
                         </group>
                     </group>
                     <group string="Orders">
-                        <field name="fsm_order_ids" nolabel="1">
+                        <field name="fsm_order_ids" nolabel="1" colspan="2">
                             <tree create="false">
                                 <field name="name" />
                                 <field name="stage_id" />


### PR DESCRIPTION
Uses the full width to display `Field Service Orders` on `Recurring Field Service Order` form view.

Before that PR, we have:
![image](https://github.com/user-attachments/assets/513e1f58-87ec-48d9-99b4-3e3738a42511)

With that PR, we have:
![image](https://github.com/user-attachments/assets/e6bc1284-498d-4076-8ec4-6978544c5c70)

