### PR TITLE
[17.0] [REM] fieldservice: unused `_get_stage_color` method

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -49,11 +49,6 @@ class FSMOrder(models.Model):
                 duration = delta.total_seconds() / 3600
             rec.duration = duration
 
-    @api.depends("stage_id")
-    def _get_stage_color(self):
-        """Get stage color"""
-        self.custom_color = self.stage_id.custom_color or "#FFFFFF"
-
     def _track_subtype(self, init_values):
         self.ensure_one()
         if "stage_id" in init_values:

--- a/fieldservice/tests/test_fsm_order.py
+++ b/fieldservice/tests/test_fsm_order.py
@@ -137,7 +137,6 @@ class TestFSMOrder(TransactionCase):
             f.date_end = f.date_start + timedelta(hours=80)
             f.request_early = fields.Datetime.today()
         order2 = f.save()
-        order._get_stage_color()
         view_id = "fieldservice.fsm_equipment_form_view"
         with Form(self.env["fsm.equipment"], view=view_id) as f:
             f.name = "Equipment 1"


### PR DESCRIPTION
The field is a non-stored related since a few versions now.
See: https://github.com/OCA/field-service/blob/9775935430d5d1919a8bc765070bfa3d7ff986af/fieldservice/models/fsm_order.py#L222


This seems to be a dead leftover code.