### PR TITLE
[IMP] fieldservice: Display FSM Location address on FSM order form view

### DIFF
--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -58,6 +58,15 @@
                         </group>
                         <group>
                             <field name="location_id" />
+                            <label for="street" string="Address" />
+                            <div class="o_address_format">
+                                <field name="street" class="o_address_street" />
+                                <field name="street2" class="o_address_street" />
+                                <field name="city" class="o_address_city" />
+                                <field name="state_name" class="o_address_state" />
+                                <field name="zip" class="o_address_zip" />
+                                <field name="country_name" class="o_address_country" />
+                            </div>
                             <field name="territory_id" invisible='1' />
                             <field name="branch_id" invisible='1' />
                             <field name="district_id" invisible='1' />


### PR DESCRIPTION
This PR improves the Field Service module by displaying the address of the related FSM location directly in the FSM order form view, reducing the need for extra navigation and providing clearer visibility of critical address details to enhance usability and efficiency.

cc https://github.com/APSL 164943

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador please review