### PR TITLE
[16.0][FIX] fieldservice_isp_account: project_id in timesheet

### DIFF
--- a/fieldservice_isp_account/models/fsm_order.py
+++ b/fieldservice_isp_account/models/fsm_order.py
@@ -65,6 +65,12 @@ class FSMOrder(models.Model):
             for cost in order.contractor_cost_ids:
                 order.contractor_total += cost.price_unit * cost.quantity
 
+    @api.onchange("project_id")
+    def onchange_project_id(self):
+        for order in self:
+            for timesheet in order.employee_timesheet_ids:
+                timesheet.project_id = order.project_id
+
     def action_complete(self):
         for order in self:
             order.account_stage = "review"


### PR DESCRIPTION
The project_id of the account_analytic_line related via fsm_order.employee_timesheet_ids take correctly the project_id from the fsm_order during creation, but if the project changes (or, if the project is only assigned after the timesheet lines have been inserted) the data is not updated in the timesheet lines.

This PR proposes to keep in sync the project_id with a simple onchange method.