### PR TITLE
[15.0][IMP] fieldservice_stock: Compute move_ids from related pickings

### DIFF
--- a/fieldservice_stock/models/fsm_order.py
+++ b/fieldservice_stock/models/fsm_order.py
@@ -54,6 +54,7 @@ class FSMOrder(models.Model):
                 lambda p: p.picking_type_id.code == "incoming"
             )
             order.return_count = len(incoming_pickings.ids)
+            order.move_ids = order.picking_ids.mapped("move_lines")
 
     def action_view_delivery(self):
         """


### PR DESCRIPTION
When linking a stock picking with an FSM order, the `move_ids` in the Inventory tab of the related FSM order are not displayed. This IMP aims to compute these `move_ids` directly from the associated pickings.

cc https://github.com/APSL 165722

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador please review