### PR TITLE
[15.0][IMP] fieldservice_route: Add access rules and permissions for fsm_route, fsm_route_day and fsm_route_dayroute models

### DIFF
--- a/fieldservice_route/__manifest__.py
+++ b/fieldservice_route/__manifest__.py
@@ -15,6 +15,7 @@
         "data/ir_sequence.xml",
         "data/fsm_route_day_data.xml",
         "data/fsm_stage_data.xml",
+        "security/ir_rule.xml",
         "security/ir.model.access.csv",
         "views/fsm_route_day.xml",
         "views/fsm_route.xml",

--- a/fieldservice_route/security/ir.model.access.csv
+++ b/fieldservice_route/security/ir.model.access.csv
@@ -1,9 +1,15 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_fsm_route_user,fsm.route.user,model_fsm_route,fieldservice.group_fsm_user,1,0,0,0
+access_fsm_route_user_own,fsm.route.user.own,model_fsm_route,fieldservice.group_fsm_user_own,1,0,0,0
 access_fsm_route_dispatcher,fsm.route.dispatcher,model_fsm_route,fieldservice.group_fsm_dispatcher,1,1,1,1
+access_fsm_route_manager,fsm.route.manager,model_fsm_route,fieldservice.group_fsm_manager,1,1,1,1
 access_fsm_route_day_user,fsm.route.day.user,model_fsm_route_day,fieldservice.group_fsm_user,1,0,0,0
+access_fsm_route_day_user_own,fsm.route.day.user.own,model_fsm_route_day,fieldservice.group_fsm_user_own,1,0,0,0
 access_fsm_route_day_dispatcher,fsm.route.day.dispatcher,model_fsm_route_day,fieldservice.group_fsm_manager,1,1,0,0
+access_fsm_route_day_manager,fsm.route.day.manager,model_fsm_route_day,fieldservice.group_fsm_manager,1,1,1,1
 access_fsm_route_dayroute_user,fsm.route.dayroute.user,model_fsm_route_dayroute,fieldservice.group_fsm_user,1,1,0,0
+access_fsm_route_dayroute_user_own,fsm.route.dayroute.user.own,model_fsm_route_dayroute,fieldservice.group_fsm_user_own,1,0,0,0
 access_fsm_route_dayroute_dispatcher,fsm.route.dayroute.dispatcher,model_fsm_route_dayroute,fieldservice.group_fsm_dispatcher,1,1,1,1
+access_fsm_route_dayroute_manager,fsm.route.dayroute.manager,model_fsm_route_dayroute,fieldservice.group_fsm_manager,1,1,1,1
 access_fsm_route_dayroute_portal,access.fsm.route.dayroute.portal,model_fsm_route_dayroute,base.group_portal,1,1,1,0
 access_ir_sequence_portal,access.ir.sequence.portal,base.model_ir_sequence,base.group_portal,1,0,0,0

--- a/fieldservice_route/security/ir_rule.xml
+++ b/fieldservice_route/security/ir_rule.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+  <record id="fsm_route_own_rule" model="ir.rule">
+    <field name="name">FSM Routes Entry (only own)</field>
+    <field name="model_id" ref="model_fsm_route" />
+    <field
+            name="domain_force"
+        >['|',('fsm_person_id.user_ids','=',user.id),('fsm_person_id','=',False)]</field>
+    <field name="groups" eval="[(4, ref('fieldservice.group_fsm_user_own'))]" />
+  </record>
+
+  <record id="fsm_route_user" model="ir.rule">
+    <field name="name">FSM Routes Entry</field>
+    <field name="model_id" ref="model_fsm_route" />
+    <field name="domain_force">[(1, '=', 1)]</field>
+    <field name="groups" eval="[(4, ref('fieldservice.group_fsm_user'))]" />
+  </record>
+
+  <record id="fsm_route_dayroute_own_rule" model="ir.rule">
+    <field name="name">FSM Route DayRoutes Entry (only own)</field>
+    <field name="model_id" ref="model_fsm_route_dayroute" />
+    <field
+            name="domain_force"
+        >['|',('person_id.user_ids','=',user.id),('person_id','=',False)]</field>
+    <field name="groups" eval="[(4, ref('fieldservice.group_fsm_user_own'))]" />
+  </record>
+
+  <record id="fsm_route_dayroute_user" model="ir.rule">
+    <field name="name">FSM Route DayRoutes Entry</field>
+    <field name="model_id" ref="model_fsm_route_dayroute" />
+    <field name="domain_force">[(1, '=', 1)]</field>
+    <field name="groups" eval="[(4, ref('fieldservice.group_fsm_user'))]" />
+  </record>
+
+</odoo>


### PR DESCRIPTION
When managing fsm_route, fsm_route_day and fsm_route_dayroute records with the "User Own" group, I wasn't able to access any of the records nor the fsm_orders that were linked to a dayroute. This IMP adds access rules to ensure "User Own" members see only their assigned records, while managers have full access.

cc https://github.com/APSL 166041

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador please review