### PR TITLE
[15.0][IMP] fieldservice: Add scheduled_date_end to tree view

### DIFF
--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -201,6 +201,7 @@
         <field name="arch" type="xml">
             <tree name="orders" default_order="scheduled_date_start">
                 <field name="scheduled_date_start" />
+                <field name="scheduled_date_end" />
                 <field name="name" />
                 <field name="location_id" />
                 <field name="person_id" />


### PR DESCRIPTION
The scheduled_date_end field is added to the tree view to improve visibility of task deadlines and scheduling.

cc https://github.com/APSL 165534

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador please review