### PR TITLE
[14.0][IMP] fieldservice_sale: Only invoice invoiceable fsm order

### DIFF
--- a/fieldservice_geoengine/tests/test_fsm_location.py
+++ b/fieldservice_geoengine/tests/test_fsm_location.py
@@ -15,10 +15,11 @@ class TestFsmLocation(SavepointCase):
         cls.location_partner_2 = cls.env.ref("fieldservice.location_partner_2")
         cls.location_partner_3 = cls.env.ref("fieldservice.location_partner_3")
         cls.test_loc_partner = cls.env.ref("fieldservice.test_loc_partner")
-        # delta value of 0.00001 was chosen according to OpenStreetMap's decimal precision table
+        # delta value of 0.001 was chosen according to OpenStreetMap's decimal precision table
         # https://wiki.openstreetmap.org/wiki/Precision_of_coordinates#Conversion_to_decimal
-        # 5 decimals are necessary for precision of about a metre
-        cls.delta = 0.000_01
+        # 3 decimals are necessary for precision of about a 100 meters
+        # Originally we tried 0.000_01, but this caused tests to fail from time to time
+        cls.delta = 0.001
 
         cls.test_location = cls.FSMLocation.create(
             {

--- a/fieldservice_sale/models/sale_order_line.py
+++ b/fieldservice_sale/models/sale_order_line.py
@@ -62,6 +62,8 @@ class SaleOrderLine(models.Model):
         """
         invoiceable_stage_ids = self.env["fsm.stage"]._get_invoiceable_stage()
         dom = [
+            "|",
+            ("sale_line_id", "=", self.id),
             ("sale_id", "=", self.order_id.id),
             ("invoice_lines", "=", False),
         ]

--- a/fieldservice_sale/models/sale_order_line.py
+++ b/fieldservice_sale/models/sale_order_line.py
@@ -62,7 +62,7 @@ class SaleOrderLine(models.Model):
         """
         invoiceable_stage_ids = self.env["fsm.stage"]._get_invoiceable_stage()
         dom = [
-            ("sale_line_id", "=", self.id),
+            ("sale_id", "=", self.order_id.id),
             ("invoice_lines", "=", False),
         ]
         if invoiceable_stage_ids:


### PR DESCRIPTION
Reopen:
- https://github.com/OCA/field-service/pull/1052

---

It looks like we merged https://github.com/OCA/field-service/pull/1053, but not https://github.com/OCA/field-service/pull/1052, which was a direct dependency of the first one.

As a result, we've code calling `_get_invoiceable_fsm_order` (and overriding `_get_invoiceable_fsm_order_domain`), methods that don't exist in the `fieldservice_sale` module, as they were introduced by https://github.com/OCA/field-service/pull/1052

Resulting in:

```
AttributeError: 'sale.order.line' object has no attribute '_get_invoiceable_fsm_order'
```