### PR TITLE
[16.0][IMP] fieldservice_recurring: Expanding fields to full form width

### DIFF
--- a/fieldservice_recurring/views/fsm_recurring.xml
+++ b/fieldservice_recurring/views/fsm_recurring.xml
@@ -79,7 +79,7 @@
                         </group>
                     </group>
                     <group string="Orders">
-                        <field name="fsm_order_ids" nolabel="1">
+                        <field name="fsm_order_ids" colspan="2" nolabel="1">
                             <tree create="false">
                                 <field name="name" />
                                 <field name="stage_id" />


### PR DESCRIPTION
After Migration to 16.0:
  One2many fields outside of a notebook are not expanding to the full form width by default. One should put colspan="2" for achieving such effect.

  So, included "One2many" field "fsm_order_ids" with "colspan=2" to achieve it.