### PR TITLE
[IMP] fieldservice_portal: order visibility by stage

### DIFF
--- a/fieldservice_portal/README.rst
+++ b/fieldservice_portal/README.rst
@@ -36,6 +36,19 @@ to monitor work orders related to their locations.
 .. contents::
    :local:
 
+Configuration
+=============
+
+Set Portal Visibility for Order Stages
+
+You are able to control which stages of field service orders are visible to
+portal users by enabling or disabling portal visiblity option on a stage.
+By default, all stages are visible in the portal. Disable the option to hide
+
+#. Go to Field Service > Configuration > Stages
+#. Select an order stage.
+#. Toggle the Visible in Portal option as desired
+
 Bug Tracker
 ===========
 

--- a/fieldservice_portal/__init__.py
+++ b/fieldservice_portal/__init__.py
@@ -1,1 +1,2 @@
+from . import models
 from . import controllers

--- a/fieldservice_portal/__manifest__.py
+++ b/fieldservice_portal/__manifest__.py
@@ -18,6 +18,7 @@
         "security/portal_security.xml",
         "views/fsm_order_template.xml",
         "views/portal_template.xml",
+        "views/fsm_stage.xml",
     ],
     "demo": [
         "demo/fsm_location_demo.xml",

--- a/fieldservice_portal/models/__init__.py
+++ b/fieldservice_portal/models/__init__.py
@@ -1,0 +1,1 @@
+from . import fsm_stage

--- a/fieldservice_portal/models/fsm_stage.py
+++ b/fieldservice_portal/models/fsm_stage.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2025, Brian McMaster
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class FSMStage(models.Model):
+    _inherit = "fsm.stage"
+
+    portal_visible = fields.Boolean(
+        string="Visible in Portal",
+        default=True,
+        help="Enable to display field service orders based on it's stage in the portal",
+    )

--- a/fieldservice_portal/readme/CONFIGURE.rst
+++ b/fieldservice_portal/readme/CONFIGURE.rst
@@ -1,0 +1,9 @@
+Set Portal Visibility for Order Stages
+
+You are able to control which stages of field service orders are visible to
+portal users by enabling or disabling portal visiblity option on a stage.
+By default, all stages are visible in the portal. Disable the option to hide
+
+#. Go to Field Service > Configuration > Stages
+#. Select an order stage.
+#. Toggle the Visible in Portal option as desired

--- a/fieldservice_portal/static/description/index.html
+++ b/fieldservice_portal/static/description/index.html
@@ -375,17 +375,30 @@ to monitor work orders related to their locations.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-4">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-5">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
+<p>Set Portal Visibility for Order Stages</p>
+<p>You are able to control which stages of field service orders are visible to
+portal users by enabling or disabling portal visiblity option on a stage.
+By default, all stages are visible in the portal. Disable the option to hide</p>
+<ol class="arabic simple">
+<li>Go to Field Service &gt; Configuration &gt; Stages</li>
+<li>Select an order stage.</li>
+<li>Toggle the Visible in Portal option as desired</li>
+</ol>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/field-service/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -393,15 +406,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-2">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-3">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
 <ul class="simple">
 <li>PyTech SRL</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-4">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
 <ul>
 <li><p class="first"><a class="reference external" href="https://www.pytech.it">PyTech SRL</a>:</p>
 <blockquote>
@@ -423,7 +436,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/fieldservice_portal/views/fsm_stage.xml
+++ b/fieldservice_portal/views/fsm_stage.xml
@@ -1,0 +1,11 @@
+<odoo>
+    <record id="fsm_stage_form_view" model="ir.ui.view">
+        <field name="model">fsm.stage</field>
+        <field name="inherit_id" ref="fieldservice.fsm_stage_form_view" />
+        <field name="arch" type="xml">
+            <field name="is_default" position="after">
+                <field name="portal_visible" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Adds a field on `fsm_stage` that allows to enable or disable visibility of fsm orders in the portal
Adds a method `_prepare_fsm_orders_domain()` that returns a domain for searching fsm orders able to be shown on the portal.  This could be overridden for other needs