### PR TITLE
[15.0][IMP] fieldservice_stock: Add setting to enable/disable auto-validation of pickings on FSM order completion

### DIFF
--- a/fieldservice_stock/README.rst
+++ b/fieldservice_stock/README.rst
@@ -59,6 +59,11 @@ If you are in a multi-warehouse situation:
 * Create or select a territory
 * Set the warehouse that will serve this territory
 
+If you want to enable autovalidation of related pickings when completing an FSM order:
+
+* Go to Field Service > Configuration > Settings
+* Under the 'Orders' tab, check the 'Auto Validate FSM Pickings' option
+
 Usage
 =====
 
@@ -99,6 +104,8 @@ Contributors
 * Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 * Marcel Savegnago <marcel.savegnago@escodoo.com.br>
 * Freni Patel <fpatel@opensourceintegrators.com>
+* `APSL-Nagarro <https://www.apsl.tech>`_:
+  * Patryk Pyczko <ppyczko@apsl.net>
 
 Other credits
 ~~~~~~~~~~~~~

--- a/fieldservice_stock/__manifest__.py
+++ b/fieldservice_stock/__manifest__.py
@@ -19,6 +19,7 @@
         "views/fsm_order.xml",
         "views/stock.xml",
         "views/stock_picking.xml",
+        "views/res_config_settings.xml",
     ],
     "license": "AGPL-3",
     "development_status": "Beta",

--- a/fieldservice_stock/i18n/ca.po
+++ b/fieldservice_stock/i18n/ca.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-17 12:10+0000\n"
-"PO-Revision-Date: 2025-02-17 12:10+0000\n"
+"POT-Creation-Date: 2025-02-17 12:09+0000\n"
+"PO-Revision-Date: 2025-02-17 12:09+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,13 +18,13 @@ msgstr ""
 #. module: fieldservice_stock
 #: model_terms:ir.ui.view,arch_db:fieldservice_stock.view_fsm_order_form_inherit_stock
 msgid "Allocated Quantity"
-msgstr ""
+msgstr "Quantitat Assignada"
 
 #. module: fieldservice_stock
 #: model:ir.model.fields,field_description:fieldservice_stock.field_res_config_settings__auto_validate_pickings
 #: model_terms:ir.ui.view,arch_db:fieldservice_stock.res_config_settings_view_form_fsm_stock
 msgid "Auto Validate FSM Pickings"
-msgstr ""
+msgstr "Validació Automàtica de Recollides FSM"
 
 #. module: fieldservice_stock
 #: model_terms:ir.ui.view,arch_db:fieldservice_stock.res_config_settings_view_form_fsm_stock
@@ -32,48 +32,50 @@ msgid ""
 "Automatically validates related stock pickings when an FSM Order is "
 "completed."
 msgstr ""
+"Valida automàticament les recollides d'estoc relacionades quan es completa "
+"una ordre FSM."
 
 #. module: fieldservice_stock
 #: model:ir.model,name:fieldservice_stock.model_res_config_settings
 msgid "Config Settings"
-msgstr ""
+msgstr "Ajustos de configuració"
 
 #. module: fieldservice_stock
 #: model_terms:ir.ui.view,arch_db:fieldservice_stock.view_fsm_order_form_inherit_stock
 msgid "Deliveries"
-msgstr ""
+msgstr "Lliuraments"
 
 #. module: fieldservice_stock
 #: model:ir.model.fields,field_description:fieldservice_stock.field_fsm_order__delivery_count
 msgid "Delivery Orders"
-msgstr ""
+msgstr "Ordres de Lliurament"
 
 #. module: fieldservice_stock
 #: model_terms:ir.ui.view,arch_db:fieldservice_stock.view_fsm_order_form_inherit_stock
 msgid "Done Quantity"
-msgstr ""
+msgstr "Quantitat Realitzada"
 
 #. module: fieldservice_stock
 #: model:ir.model,name:fieldservice_stock.model_fsm_wizard
 msgid "FSM Record Conversion"
-msgstr ""
+msgstr "Conversió de Registre FSM"
 
 #. module: fieldservice_stock
 #: model_terms:ir.ui.view,arch_db:fieldservice_stock.fsm_stock_picking_form
 msgid "Field Service Information"
-msgstr ""
+msgstr "Informació del Servei de Camp"
 
 #. module: fieldservice_stock
 #: model:ir.model,name:fieldservice_stock.model_fsm_location
 msgid "Field Service Location"
-msgstr ""
+msgstr "Ubicació del Servei de Camp"
 
 #. module: fieldservice_stock
 #: model:ir.model,name:fieldservice_stock.model_fsm_order
 #: model:ir.model.fields,field_description:fieldservice_stock.field_stock_move__fsm_order_id
 #: model:ir.model.fields,field_description:fieldservice_stock.field_stock_picking__fsm_order_id
 msgid "Field Service Order"
-msgstr ""
+msgstr "Ordre de Servei de Camp"
 
 #. module: fieldservice_stock
 #: model:ir.model.fields,help:fieldservice_stock.field_res_config_settings__auto_validate_pickings
@@ -81,96 +83,98 @@ msgid ""
 "If enabled, related stock pickings will be automatically validated when an "
 "FSM order is completed."
 msgstr ""
+"Si està habilitat, les recollides d'estoc relacionades es validaran "
+"automàticament quan es completi una ordre FSM."
 
 #. module: fieldservice_stock
 #: model:ir.ui.menu,name:fieldservice_stock.menu_fsm_stock_inventory
 #: model_terms:ir.ui.view,arch_db:fieldservice_stock.view_fsm_order_form_inherit_stock
 msgid "Inventory"
-msgstr ""
+msgstr "Inventari"
 
 #. module: fieldservice_stock
 #: model:ir.model.fields,field_description:fieldservice_stock.field_fsm_location__inventory_location_id
 #: model:ir.model.fields,field_description:fieldservice_stock.field_fsm_order__inventory_location_id
 msgid "Inventory Location"
-msgstr ""
+msgstr "Ubicació d'Inventari"
 
 #. module: fieldservice_stock
 #: model:ir.model.fields,field_description:fieldservice_stock.field_fsm_order__move_ids
 msgid "Operations"
-msgstr ""
+msgstr "Operacions"
 
 #. module: fieldservice_stock
 #: model:ir.model.fields,field_description:fieldservice_stock.field_fsm_order__procurement_group_id
 msgid "Procurement Group"
-msgstr ""
+msgstr "Grup de Procés"
 
 #. module: fieldservice_stock
 #: model:ir.ui.menu,name:fieldservice_stock.menu_fsm_product
 msgid "Products"
-msgstr ""
+msgstr "Productes"
 
 #. module: fieldservice_stock
 #: model_terms:ir.ui.view,arch_db:fieldservice_stock.view_fsm_order_form_inherit_stock
 msgid "Reference"
-msgstr ""
+msgstr "Referència"
 
 #. module: fieldservice_stock
 #: model_terms:ir.ui.view,arch_db:fieldservice_stock.view_fsm_order_form_inherit_stock
 msgid "Requested Quantity"
-msgstr ""
+msgstr "Quantitat Sol·licitada"
 
 #. module: fieldservice_stock
 #: model:ir.model.fields,field_description:fieldservice_stock.field_fsm_order__return_count
 msgid "Return Orders"
-msgstr ""
+msgstr "Ordres de Retorn"
 
 #. module: fieldservice_stock
 #: model_terms:ir.ui.view,arch_db:fieldservice_stock.view_fsm_order_form_inherit_stock
 msgid "Returns"
-msgstr ""
+msgstr "Retorns"
 
 #. module: fieldservice_stock
 #: model:ir.model.fields,field_description:fieldservice_stock.field_fsm_location__shipping_address_id
 msgid "Shipping Location"
-msgstr ""
+msgstr "Ubicació d'Enviament"
 
 #. module: fieldservice_stock
 #: model:ir.model,name:fieldservice_stock.model_stock_move
 msgid "Stock Move"
-msgstr ""
+msgstr "Moviment d'estoc"
 
 #. module: fieldservice_stock
 #: model:ir.model,name:fieldservice_stock.model_stock_rule
 msgid "Stock Rule"
-msgstr ""
+msgstr "Regla d'estoc"
 
 #. module: fieldservice_stock
 #: model:ir.model,name:fieldservice_stock.model_res_territory
 msgid "Territory"
-msgstr ""
+msgstr "Territori"
 
 #. module: fieldservice_stock
 #: model:ir.model,name:fieldservice_stock.model_stock_picking
 msgid "Transfer"
-msgstr ""
+msgstr "Transferència"
 
 #. module: fieldservice_stock
 #: model:ir.model.fields,field_description:fieldservice_stock.field_fsm_order__picking_ids
 msgid "Transfers"
-msgstr ""
+msgstr "Transferències"
 
 #. module: fieldservice_stock
 #: model_terms:ir.ui.view,arch_db:fieldservice_stock.view_fsm_order_form_inherit_stock
 msgid "Unit of Measure"
-msgstr ""
+msgstr "Unitat de Mesura"
 
 #. module: fieldservice_stock
 #: model:ir.model.fields,field_description:fieldservice_stock.field_fsm_order__warehouse_id
 #: model:ir.model.fields,field_description:fieldservice_stock.field_res_territory__warehouse_id
 msgid "Warehouse"
-msgstr ""
+msgstr "Magatzem"
 
 #. module: fieldservice_stock
 #: model:ir.model.fields,help:fieldservice_stock.field_fsm_order__warehouse_id
 msgid "Warehouse used to ship the materials"
-msgstr ""
+msgstr "Magatzem utilitzat per enviar els materials"

--- a/fieldservice_stock/i18n/es.po
+++ b/fieldservice_stock/i18n/es.po
@@ -4,22 +4,39 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 12.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2023-03-02 16:30+0000\n"
-"Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
-"Language-Team: none\n"
-"Language: es\n"
+"POT-Creation-Date: 2025-02-17 12:10+0000\n"
+"PO-Revision-Date: 2025-02-17 12:10+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.14.1\n"
+"Plural-Forms: \n"
 
 #. module: fieldservice_stock
 #: model_terms:ir.ui.view,arch_db:fieldservice_stock.view_fsm_order_form_inherit_stock
 msgid "Allocated Quantity"
 msgstr "Cantidad Asignada"
+
+#. module: fieldservice_stock
+#: model:ir.model.fields,field_description:fieldservice_stock.field_res_config_settings__auto_validate_pickings
+#: model_terms:ir.ui.view,arch_db:fieldservice_stock.res_config_settings_view_form_fsm_stock
+msgid "Auto Validate FSM Pickings"
+msgstr "Validar automáticamente los albaranes FSM"
+
+#. module: fieldservice_stock
+#: model_terms:ir.ui.view,arch_db:fieldservice_stock.res_config_settings_view_form_fsm_stock
+msgid ""
+"Automatically validates related stock pickings when an FSM Order is "
+"completed."
+msgstr "Valida automáticamente los albaranes relacionados cuando se completa una orden FSM."
+
+#. module: fieldservice_stock
+#: model:ir.model,name:fieldservice_stock.model_res_config_settings
+msgid "Config Settings"
+msgstr "Opciones de configuración"
 
 #. module: fieldservice_stock
 #: model_terms:ir.ui.view,arch_db:fieldservice_stock.view_fsm_order_form_inherit_stock
@@ -57,6 +74,13 @@ msgstr "Ubicación del Servicio de Campo"
 #: model:ir.model.fields,field_description:fieldservice_stock.field_stock_picking__fsm_order_id
 msgid "Field Service Order"
 msgstr "Orden de Servicio de Campo"
+
+#. module: fieldservice_stock
+#: model:ir.model.fields,help:fieldservice_stock.field_res_config_settings__auto_validate_pickings
+msgid ""
+"If enabled, related stock pickings will be automatically validated when an "
+"FSM order is completed."
+msgstr "Si está habilitado, los albaranes relacionados se validarán automáticamente cuando se complete una orden FSM."
 
 #. module: fieldservice_stock
 #: model:ir.ui.menu,name:fieldservice_stock.menu_fsm_stock_inventory
@@ -113,12 +137,12 @@ msgstr "Lugar de Envío"
 #. module: fieldservice_stock
 #: model:ir.model,name:fieldservice_stock.model_stock_move
 msgid "Stock Move"
-msgstr "Movimiento de Stock"
+msgstr "Movimiento de existencias"
 
 #. module: fieldservice_stock
 #: model:ir.model,name:fieldservice_stock.model_stock_rule
 msgid "Stock Rule"
-msgstr "Regla de Stock"
+msgstr "Regla de Inventario"
 
 #. module: fieldservice_stock
 #: model:ir.model,name:fieldservice_stock.model_res_territory
@@ -128,7 +152,7 @@ msgstr "Territorio"
 #. module: fieldservice_stock
 #: model:ir.model,name:fieldservice_stock.model_stock_picking
 msgid "Transfer"
-msgstr "Transferir"
+msgstr "Albarán"
 
 #. module: fieldservice_stock
 #: model:ir.model.fields,field_description:fieldservice_stock.field_fsm_order__picking_ids
@@ -150,85 +174,3 @@ msgstr "Almacén"
 #: model:ir.model.fields,help:fieldservice_stock.field_fsm_order__warehouse_id
 msgid "Warehouse used to ship the materials"
 msgstr "Almacén utilizado para enviar los materiales"
-
-#~ msgid "Moves"
-#~ msgstr "Movimientos"
-
-#~ msgid "Please create a stock request."
-#~ msgstr "Por favor cree una solicitud de stock."
-
-#~ msgid "Cancel"
-#~ msgstr "Cancelar"
-
-#~ msgid "Cancelled"
-#~ msgstr "Cancelado"
-
-#, fuzzy
-#~ msgid "Create Fsm Equipment"
-#~ msgstr "Crea Equipos FSM"
-
-#~ msgid "Creates a FSM Equipment"
-#~ msgstr "Crea Equipos FSM"
-
-#~ msgid "Current Inventory Location"
-#~ msgstr "Ubicación Actual de Inventario"
-
-#~ msgid "Done"
-#~ msgstr "Hecho"
-
-#~ msgid "Draft"
-#~ msgstr "Borrador"
-
-#~ msgid "Equipment"
-#~ msgstr "Equipo"
-
-#~ msgid "FSM Order"
-#~ msgstr "Orden FSM"
-
-#~ msgid "Field Service Equipment"
-#~ msgstr "Equipo de Servicio de Campo"
-
-#~ msgid "In progress"
-#~ msgstr "En progreso"
-
-#~ msgid "Lot/Serial"
-#~ msgstr "Lote / Serie"
-
-#~ msgid "Order Lines"
-#~ msgstr "Líneas de Pedido"
-
-#~ msgid "Product"
-#~ msgstr "Producto"
-
-#~ msgid "Product Moves (Stock Move Line)"
-#~ msgstr "Movimientos de Producto (Línea de Movimiento de Stock)"
-
-#~ msgid "Product Template"
-#~ msgstr "Plantilla de Producto"
-
-#~ msgid "Request State"
-#~ msgstr "Estado de Solicitud"
-
-#~ msgid "Serial #"
-#~ msgstr "# de Serial"
-
-#~ msgid "Set to Draft"
-#~ msgstr "Establecer en Borrador"
-
-#~ msgid "Stock Request"
-#~ msgstr "Solicitud de Stock"
-
-#~ msgid "Stock Request Order"
-#~ msgstr "Pedido de Solicitud de Stock"
-
-#~ msgid "Stock Requests"
-#~ msgstr "Solicitudes de Stock"
-
-#~ msgid "Submit"
-#~ msgstr "Enviar"
-
-#~ msgid "Submitted"
-#~ msgstr "Enviado"
-
-#~ msgid "Receipts"
-#~ msgstr "Ingresos"

--- a/fieldservice_stock/models/__init__.py
+++ b/fieldservice_stock/models/__init__.py
@@ -9,4 +9,5 @@ from . import (
     stock_rule,
     stock_picking,
     fsm_wizard,
+    res_config_settings,
 )

--- a/fieldservice_stock/models/fsm_order.py
+++ b/fieldservice_stock/models/fsm_order.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class FSMOrder(models.Model):
@@ -95,3 +96,32 @@ class FSMOrder(models.Model):
             action["views"] = [(self.env.ref("stock.view_picking_form").id, "form")]
             action["res_id"] = return_ids[0]
         return action
+
+    def action_complete(self):
+        """Validate related pickings before marking FSM Order as complete."""
+        auto_validate = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("fieldservice_stock.auto_validate_pickings", default=False)
+        )
+
+        if auto_validate:
+            for order in self:
+                for picking in order.picking_ids.filtered(
+                    lambda p: p.state in ["confirmed", "assigned"]
+                ):
+                    picking.action_assign()
+                    picking.action_set_quantities_to_reservation()
+
+                    if any(
+                        move.quantity_done < move.product_uom_qty
+                        for move in picking.move_lines
+                    ):
+                        raise ValidationError(
+                            f"Not enough stock to complete transfer for FSM Order "
+                            f"{order.name} - {picking.name}. Please check product quantities."
+                        )
+
+                    picking.button_validate()
+
+        return super().action_complete()

--- a/fieldservice_stock/models/res_config_settings.py
+++ b/fieldservice_stock/models/res_config_settings.py
@@ -1,0 +1,15 @@
+# Copyright 2025 Patryk Pyczko (APSL-Nagarro)<ppyczko@apsl.net>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    auto_validate_pickings = fields.Boolean(
+        string="Auto Validate FSM Pickings",
+        config_parameter="fieldservice_stock.auto_validate_pickings",
+        help="If enabled, related stock pickings will be automatically "
+        "validated when an FSM order is completed.",
+    )

--- a/fieldservice_stock/readme/CONFIGURE.rst
+++ b/fieldservice_stock/readme/CONFIGURE.rst
@@ -8,3 +8,8 @@ If you are in a multi-warehouse situation:
 * Go to Field Service > Configuration > Territories
 * Create or select a territory
 * Set the warehouse that will serve this territory
+
+If you want to enable autovalidation of related pickings when completing an FSM order:
+
+* Go to Field Service > Configuration > Settings
+* Under the 'Orders' tab, check the 'Auto Validate FSM Pickings' option

--- a/fieldservice_stock/readme/CONTRIBUTORS.rst
+++ b/fieldservice_stock/readme/CONTRIBUTORS.rst
@@ -3,3 +3,5 @@
 * Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 * Marcel Savegnago <marcel.savegnago@escodoo.com.br>
 * Freni Patel <fpatel@opensourceintegrators.com>
+* `APSL-Nagarro <https://www.apsl.tech>`_:
+  * Patryk Pyczko <ppyczko@apsl.net>

--- a/fieldservice_stock/static/description/index.html
+++ b/fieldservice_stock/static/description/index.html
@@ -409,6 +409,11 @@ stock operations with your field service operations.</p>
 <li>Create or select a territory</li>
 <li>Set the warehouse that will serve this territory</li>
 </ul>
+<p>If you want to enable autovalidation of related pickings when completing an FSM order:</p>
+<ul class="simple">
+<li>Go to Field Service &gt; Configuration &gt; Settings</li>
+<li>Under the ‘Orders’ tab, check the ‘Auto Validate FSM Pickings’ option</li>
+</ul>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-3">Usage</a></h1>
@@ -446,6 +451,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Serpent Consulting Services Pvt. Ltd. &lt;<a class="reference external" href="mailto:support&#64;serpentcs.com">support&#64;serpentcs.com</a>&gt;</li>
 <li>Marcel Savegnago &lt;<a class="reference external" href="mailto:marcel.savegnago&#64;escodoo.com.br">marcel.savegnago&#64;escodoo.com.br</a>&gt;</li>
 <li>Freni Patel &lt;<a class="reference external" href="mailto:fpatel&#64;opensourceintegrators.com">fpatel&#64;opensourceintegrators.com</a>&gt;</li>
+<li><a class="reference external" href="https://www.apsl.tech">APSL-Nagarro</a>:
+* Patryk Pyczko &lt;<a class="reference external" href="mailto:ppyczko&#64;apsl.net">ppyczko&#64;apsl.net</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="other-credits">

--- a/fieldservice_stock/tests/__init__.py
+++ b/fieldservice_stock/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_fsm_stock
 from . import test_fsm_wizard
+from . import test_fsm_order_autovalidate

--- a/fieldservice_stock/tests/test_fsm_order_autovalidate.py
+++ b/fieldservice_stock/tests/test_fsm_order_autovalidate.py
@@ -1,0 +1,97 @@
+from odoo import fields
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+
+
+class TestFSMStockActionComplete(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.FSMOrder = cls.env["fsm.order"]
+        cls.StockPicking = cls.env["stock.picking"]
+        cls.StockMove = cls.env["stock.move"]
+        cls.Product = cls.env["product.product"].search([], limit=1)
+        cls.customer_location = cls.env.ref("stock.stock_location_customers")
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        cls.picking_type_out = cls.env.ref("stock.picking_type_out")
+        cls.partner = cls.env["res.partner"].create({"name": "Test Partner"})
+
+        cls.fsm_order = cls.FSMOrder.create(
+            {
+                "location_id": cls.env.ref("fieldservice.test_location").id,
+                "date_start": fields.Datetime.now(),
+                "date_end": fields.Datetime.now(),
+                "request_early": fields.Datetime.now(),
+                "resolution": "Test resolution",
+            }
+        )
+
+        cls.picking = cls.StockPicking.create(
+            {
+                "location_id": cls.stock_location.id,
+                "location_dest_id": cls.customer_location.id,
+                "partner_id": cls.partner.id,
+                "picking_type_id": cls.picking_type_out.id,
+                "fsm_order_id": cls.fsm_order.id,
+            }
+        )
+
+        cls.stock_move = cls.StockMove.create(
+            {
+                "name": "Move Test Product",
+                "product_id": cls.Product.id,
+                "product_uom_qty": 5.0,
+                "product_uom": cls.Product.uom_id.id,
+                "location_id": cls.stock_location.id,
+                "location_dest_id": cls.customer_location.id,
+                "picking_id": cls.picking.id,
+                "state": "confirmed",
+            }
+        )
+
+    def test_action_complete_auto_validate_disabled(self):
+        """Ensure pickings are not validated when auto_validate_pickings is False."""
+        self.env["ir.config_parameter"].sudo().set_param(
+            "fieldservice_stock.auto_validate_pickings", False
+        )
+        self.stock_move.quantity_done = self.stock_move.product_uom_qty
+        self.fsm_order.action_complete()
+        self.assertNotEqual(
+            self.picking.state,
+            "done",
+            "Picking should not validate when auto-validate is False.",
+        )
+
+    def test_action_complete_validates_pickings(self):
+        """Ensure pickings are validated when auto_validate_pickings is True."""
+        self.env["ir.config_parameter"].sudo().set_param(
+            "fieldservice_stock.auto_validate_pickings", True
+        )
+        self.stock_move.quantity_done = self.stock_move.product_uom_qty
+        self.fsm_order.action_complete()
+        self.assertEqual(
+            self.picking.state, "done", "Picking should be validated and set to 'done'."
+        )
+
+    def test_action_complete_raises_error_on_insufficient_stock(self):
+        """Ensure ValidationError is raised when stock is insufficient."""
+        self.env["ir.config_parameter"].sudo().set_param(
+            "fieldservice_stock.auto_validate_pickings", True
+        )
+        product_no_stock = self.env.ref("product.product_product_16_product_template")
+        self.StockMove.create(
+            {
+                "name": "Move Test Product - Waiting",
+                "product_id": product_no_stock.id,
+                "product_uom_qty": 5.0,
+                "product_uom": product_no_stock.uom_id.id,
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.customer_location.id,
+                "picking_id": self.picking.id,
+                "state": "confirmed",
+            }
+        )
+
+        self.picking.action_confirm()
+        with self.assertRaises(ValidationError):
+            self.fsm_order.action_complete()

--- a/fieldservice_stock/views/res_config_settings.xml
+++ b/fieldservice_stock/views/res_config_settings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+  <!-- Copyright 2025 Patryk Pyczko (APSL-Nagarro)<ppyczko@apsl.net>
+       License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+
+  <record id="res_config_settings_view_form_fsm_stock" model="ir.ui.view">
+    <field name="name">res.config.settings.view.form.fsm.stock</field>
+    <field name="model">res.config.settings</field>
+    <field name="priority" eval="40" />
+    <field name="inherit_id" ref="fieldservice.res_config_settings_view_form" />
+    <field name="arch" type="xml">
+      <xpath expr="//div[@id='orders']" position="inside">
+        <div class="col-xs-12 col-md-6 o_setting_box">
+          <div class="o_setting_left_pane">
+            <field name="auto_validate_pickings" />
+          </div>
+          <div class="o_setting_right_pane">
+            <label for="auto_validate_pickings" string="Auto Validate FSM Pickings" />
+            <div class="text-muted">
+              Automatically validates related stock pickings when an FSM Order is completed.
+            </div>
+          </div>
+        </div>
+      </xpath>
+    </field>
+  </record>
+
+
+</odoo>


### PR DESCRIPTION
Add a setting `fieldservice_stock.auto_validate_pickings` to enable automatic validation of related pickings when completing an FSM order. If a related picking lacks sufficient stock, an error is raised to inform the user.

cc https://github.com/APSL 167266

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador please review