### PR TITLE
[17.0][FIX] fieldservice-geoengine: Fix geoengine view filter

### DIFF
--- a/fieldservice_geoengine/readme/CONTRIBUTORS.md
+++ b/fieldservice_geoengine/readme/CONTRIBUTORS.md
@@ -13,3 +13,4 @@
 
 - \[APSL-Nagarro\](<https://apsl.tech>):
   - Antoni Marroig \<<amarroig@apsl.net>\>
+

--- a/fieldservice_geoengine/views/fsm_order.xml
+++ b/fieldservice_geoengine/views/fsm_order.xml
@@ -46,6 +46,7 @@
                 <field name="stage_name" />
                 <field name="shape" />
                 <field name="shape" />
+                <field name="display_name" />
                 <field name="custom_color" />
                 <templates>
                     <t t-name="info_box">


### PR DESCRIPTION
The filter of geoengine view of orders was throwing an error because 'display_name' was not found in the items, and was not showing the orders. This happened because the 'display_name' field was not included in the view.

Errors:
- Not showing current orders:
![image](https://github.com/user-attachments/assets/1750a566-6261-4e6d-bff3-06e02ce54d2f)

- Error when trying to filter:
![image](https://github.com/user-attachments/assets/b29ac1cd-3294-4f7d-ac84-09b33b1fd340)

cc https://github.com/APSL 167441

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review