### PR TITLE
[16.0][FIX] fieldservice: request_early default to current time

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -38,6 +38,9 @@ class FSMOrder(models.Model):
             return team
         raise ValidationError(_("You must create an FSM team first."))
 
+    def _default_request_early(self):
+        return fields.Datetime.now().replace(second=0)
+
     @api.depends("date_start", "date_end")
     def _compute_duration(self):
         for rec in self:
@@ -114,7 +117,8 @@ class FSMOrder(models.Model):
     )
     location_directions = fields.Html()
     request_early = fields.Datetime(
-        string="Earliest Request Date", default=datetime.now()
+        string="Earliest Request Date",
+        default=lambda self: self._default_request_early(),
     )
     color = fields.Integer("Color Index")
     company_id = fields.Many2one(


### PR DESCRIPTION
Fixes an issue where the default was snapshot at installation time

This is a regression, the issue was first fixes on #872 Commit 3431b49ae00122275ca564c6107dd832b117504f

Which was partially reverted on #950
Commit 090eb57236da3f02a4763157ad41534d9c4f5594

FW of https://github.com/OCA/field-service/pull/1328