### PR TITLE
[16.0][FIX] fieldservice_account + fieldservice_sale: Post-install test + fallback to load CoA

### DIFF
--- a/fieldservice_account/tests/test_fsm_account.py
+++ b/fieldservice_account/tests/test_fsm_account.py
@@ -37,14 +37,17 @@ class FSMAccountCase(TransactionCase):
             {"name": "Test Loc Partner 2", "phone": "123", "email": "tlp@example.com"}
         )
         # create expected FSM Location to compare to converted FSM Location
-        cls.test_location = cls.env["fsm.location"].create(
-            {
-                "name": "Test Location",
-                "phone": "123",
-                "email": "tp@email.com",
-                "partner_id": cls.test_loc_partner.id,
-                "owner_id": cls.test_loc_partner.id,
-            }
+        cls.test_location = (
+            cls.env["fsm.location"]
+            .with_context(default_owner_id=cls.test_loc_partner.id)
+            .create(
+                {
+                    "name": "Test Location",
+                    "phone": "123",
+                    "email": "tp@email.com",
+                    "partner_id": cls.test_loc_partner.id,
+                }
+            )
         )
         cls.test_order = cls.env["fsm.order"].create(
             {

--- a/fieldservice_account/tests/test_fsm_account.py
+++ b/fieldservice_account/tests/test_fsm_account.py
@@ -3,55 +3,67 @@
 
 from datetime import datetime, timedelta
 
+from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
 
+@tagged("-at_install", "post_install")
 class FSMAccountCase(TransactionCase):
-    def setUp(self):
-        super(FSMAccountCase, self).setUp()
-        self.Wizard = self.env["fsm.wizard"]
-        self.WorkOrder = self.env["fsm.order"]
-        self.AccountInvoice = self.env["account.move"]
-        self.AccountInvoiceLine = self.env["account.move.line"]
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
+        cls.Wizard = cls.env["fsm.wizard"]
+        cls.WorkOrder = cls.env["fsm.order"]
+        cls.AccountInvoice = cls.env["account.move"]
+        cls.AccountInvoiceLine = cls.env["account.move.line"]
         # create a Res Partner
-        self.test_partner = self.env["res.partner"].create(
+        cls.test_partner = cls.env["res.partner"].create(
             {"name": "Test Partner", "phone": "123", "email": "tp@email.com"}
         )
         # create a Res Partner to be converted to FSM Location/Person
-        self.test_loc_partner = self.env["res.partner"].create(
+        cls.test_loc_partner = cls.env["res.partner"].create(
             {"name": "Test Loc Partner", "phone": "ABC", "email": "tlp@email.com"}
         )
-        self.test_loc_partner2 = self.env["res.partner"].create(
+        cls.test_loc_partner2 = cls.env["res.partner"].create(
             {"name": "Test Loc Partner 2", "phone": "123", "email": "tlp@example.com"}
         )
         # create expected FSM Location to compare to converted FSM Location
-        self.test_location = self.env["fsm.location"].create(
+        cls.test_location = cls.env["fsm.location"].create(
             {
                 "name": "Test Location",
                 "phone": "123",
                 "email": "tp@email.com",
-                "partner_id": self.test_loc_partner.id,
-                "owner_id": self.test_loc_partner.id,
+                "partner_id": cls.test_loc_partner.id,
+                "owner_id": cls.test_loc_partner.id,
             }
         )
-        self.test_order = self.env["fsm.order"].create(
+        cls.test_order = cls.env["fsm.order"].create(
             {
-                "location_id": self.test_location.id,
+                "location_id": cls.test_location.id,
                 "date_start": datetime.today(),
                 "date_end": datetime.today() + timedelta(hours=2),
                 "request_early": datetime.today(),
             }
         )
-        self.test_order2 = self.env["fsm.order"].create(
+        cls.test_order2 = cls.env["fsm.order"].create(
             {
-                "location_id": self.test_location.id,
+                "location_id": cls.test_location.id,
                 "date_start": datetime.today(),
                 "date_end": datetime.today() + timedelta(hours=2),
                 "request_early": datetime.today(),
             }
         )
-        company = self.env.user.company_id
-        self.default_account_revenue = self.env["account.account"].search(
+        company = cls.env.user.company_id
+        cls.default_account_revenue = cls.env["account.account"].search(
             [
                 ("company_id", "=", company.id),
                 ("account_type", "=", "income"),
@@ -64,9 +76,9 @@ class FSMAccountCase(TransactionCase):
             limit=1,
         )
 
-        self.test_invoice = self.env["account.move"].create(
+        cls.test_invoice = cls.env["account.move"].create(
             {
-                "partner_id": self.test_partner.id,
+                "partner_id": cls.test_partner.id,
                 "move_type": "out_invoice",
                 "invoice_date": datetime.today().date(),
                 "invoice_line_ids": [
@@ -86,7 +98,7 @@ class FSMAccountCase(TransactionCase):
                         0,
                         {
                             "name": "line_debit",
-                            "account_id": self.default_account_revenue.id,
+                            "account_id": cls.default_account_revenue.id,
                         },
                     ),
                     (
@@ -94,15 +106,15 @@ class FSMAccountCase(TransactionCase):
                         0,
                         {
                             "name": "line_credit",
-                            "account_id": self.default_account_revenue.id,
+                            "account_id": cls.default_account_revenue.id,
                         },
                     ),
                 ],
             }
         )
-        self.test_invoice2 = self.env["account.move"].create(
+        cls.test_invoice2 = cls.env["account.move"].create(
             {
-                "partner_id": self.test_partner.id,
+                "partner_id": cls.test_partner.id,
                 "move_type": "out_invoice",
                 "invoice_date": datetime.today().date(),
                 "invoice_line_ids": [

--- a/fieldservice_account_analytic/models/fsm_location.py
+++ b/fieldservice_account_analytic/models/fsm_location.py
@@ -12,6 +12,17 @@ class FSMLocation(models.Model):
     )
 
     @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        if (
+            res.get("owner_id")
+            and "customer_id" in fields
+            and not res.get("customer_id")
+        ):
+            res["customer_id"] = res.get("owner_id")
+        return res
+
+    @api.model
     def get_default_customer(self):
         if self.fsm_parent_id:
             return self.fsm_parent_id.customer_id.id


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with the error:

`odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale`

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa