### PR TITLE
[17.0][IMP] fieldservice_crm: Added button to create FSM orders directly from leads

### DIFF
--- a/fieldservice_crm/README.rst
+++ b/fieldservice_crm/README.rst
@@ -92,6 +92,7 @@ Contributors
 -  `APSL <https://apsl.tech>`__:
 
    -  Antoni Marroig <amarroig@apsl.net>
+   -  Bernat Obrador <bobrador@apsl.net>
 
 Other credits
 -------------

--- a/fieldservice_crm/i18n/es.po
+++ b/fieldservice_crm/i18n/es.po
@@ -4,17 +4,16 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2023-07-22 21:08+0000\n"
-"Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
-"Language-Team: none\n"
-"Language: es\n"
+"POT-Creation-Date: 2025-03-05 09:16+0000\n"
+"PO-Revision-Date: 2025-03-05 09:16+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"Plural-Forms: \n"
 
 #. module: fieldservice_crm
 #: model:ir.model.fields,field_description:fieldservice_crm.field_crm_lead__fsm_order_count
@@ -25,6 +24,18 @@ msgstr "# Pedidos FSM"
 #: model:ir.model.fields,field_description:fieldservice_crm.field_fsm_location__opportunity_count
 msgid "# Opportunities"
 msgstr "# Oportunidades"
+
+#. module: fieldservice_crm
+#: model_terms:ir.ui.view,arch_db:fieldservice_crm.fieldservice_crm_form_view
+msgid "Create FS Order"
+msgstr "Crear Orden FS"
+
+#. module: fieldservice_crm
+#. odoo-python
+#: code:addons/fieldservice_crm/models/crm_lead.py:0
+#, python-format
+msgid "Create FSM Order"
+msgstr "Crear Orden FSM"
 
 #. module: fieldservice_crm
 #: model_terms:ir.ui.view,arch_db:fieldservice_crm.fieldservice_crm_form_view
@@ -60,6 +71,13 @@ msgstr "Oportunidades"
 #: model:ir.model.fields,field_description:fieldservice_crm.field_fsm_order__opportunity_id
 msgid "Opportunity"
 msgstr "Oportunidad"
+
+#. module: fieldservice_crm
+#. odoo-python
+#: code:addons/fieldservice_crm/models/crm_lead.py:0
+#, python-format
+msgid "Please select a customer."
+msgstr "Por favor seleccione un cliente."
 
 #. module: fieldservice_crm
 #: model:ir.model.fields,field_description:fieldservice_crm.field_crm_lead__fsm_order_ids

--- a/fieldservice_crm/models/crm_lead.py
+++ b/fieldservice_crm/models/crm_lead.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2019, Patrick Wilson
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import _, fields, models
+from odoo.exceptions import UserError
 
 
 class Lead(models.Model):
@@ -18,3 +19,27 @@ class Lead(models.Model):
     def _compute_fsm_order_count(self):
         for rec in self:
             rec.fsm_order_count = len(rec.fsm_order_ids)
+
+    def create_fsm_order(self):
+        self.ensure_one()
+
+        if not self.partner_id:
+            raise UserError(_("Please select a customer."))
+
+        # If not location is selected use the partner's location
+        if not self.fsm_location_id:
+            if not self.partner_id.fsm_location:
+                self.env["fsm.wizard"].action_convert_location(self.partner_id)
+            self.fsm_location_id = self.partner_id.fsm_location_id
+
+        return {
+            "name": _("Create FSM Order"),
+            "type": "ir.actions.act_window",
+            "res_model": "fsm.order",
+            "view_mode": "form",
+            "target": "new",
+            "context": {
+                "default_opportunity_id": self.id,
+                "default_location_id": self.fsm_location_id.id,
+            },
+        }

--- a/fieldservice_crm/readme/CONTRIBUTORS.md
+++ b/fieldservice_crm/readme/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
 - Freni Patel \<<fpatel@opensourceintegrators.com>\>
 - [APSL](https://apsl.tech):
   - Antoni Marroig   \<<amarroig@apsl.net>\>
+  - Bernat Obrador \<<bobrador@apsl.net>\>

--- a/fieldservice_crm/static/description/index.html
+++ b/fieldservice_crm/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -438,6 +439,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Freni Patel &lt;<a class="reference external" href="mailto:fpatel&#64;opensourceintegrators.com">fpatel&#64;opensourceintegrators.com</a>&gt;</li>
 <li><a class="reference external" href="https://apsl.tech">APSL</a>:<ul>
 <li>Antoni Marroig &lt;<a class="reference external" href="mailto:amarroig&#64;apsl.net">amarroig&#64;apsl.net</a>&gt;</li>
+<li>Bernat Obrador &lt;<a class="reference external" href="mailto:bobrador&#64;apsl.net">bobrador&#64;apsl.net</a>&gt;</li>
 </ul>
 </li>
 </ul>
@@ -452,7 +454,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-10">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/fieldservice_crm/tests/test_fsm_crm.py
+++ b/fieldservice_crm/tests/test_fsm_crm.py
@@ -1,7 +1,15 @@
+import requests
+
+from odoo.exceptions import UserError
 from odoo.tests import common
 
 
 class TestFieldserviceCrm(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._super_send = requests.Session.send
+        super().setUpClass()
+
     def test_fieldservicecrm(self):
         location_1 = self.env["fsm.location"].create(
             {
@@ -28,3 +36,38 @@ class TestFieldserviceCrm(common.TransactionCase):
 
         location_1._compute_opportunity_count()
         self.assertEqual(location_1.opportunity_count, 1)
+
+    # Needed to avoid conflicts with fieldservice_geoengine when it's installed
+    @classmethod
+    def _request_handler(cls, s, r, /, **kw):
+        """Don't block external requests."""
+        return cls._super_send(s, r, **kw)
+
+    def test_create_fs_order_from_lead(self):
+        partner_1 = self.env["res.partner"].create(
+            {
+                "name": "Test partner",
+                "street": "123 Test St",
+                "city": "Test City",
+                "zip": "12345",
+                "country_id": self.env.ref("base.us").id,
+            }
+        )
+        crm_1 = self.env["crm.lead"].create(
+            {
+                "name": "Test CRM",
+                "partner_id": partner_1.id,
+            }
+        )
+        crm_1.create_fsm_order()
+        self.assertTrue(partner_1.fsm_location)
+        self.assertEqual(partner_1.fsm_location_id, crm_1.fsm_location_id)
+
+    def test_create_fs_order_from_lead_without_partner(self):
+        crm_1 = self.env["crm.lead"].create(
+            {
+                "name": "Test CRM",
+            }
+        )
+        with self.assertRaises(UserError):
+            crm_1.create_fsm_order()

--- a/fieldservice_crm/views/crm_lead.xml
+++ b/fieldservice_crm/views/crm_lead.xml
@@ -26,6 +26,18 @@
                 </button>
             </xpath>
             <xpath
+                expr="//header/button[@name='action_set_won_rainbowman']"
+                position="before"
+            >
+                <button
+                    string="Create FS Order"
+                    name="create_fsm_order"
+                    type="object"
+                    class="oe_highlight"
+                    groups="fieldservice.group_fsm_user"
+                />
+            </xpath>
+            <xpath
                 expr="//group[@name='lead_partner']/field[@name='partner_id']"
                 position="after"
             >


### PR DESCRIPTION
This implementation adds the possibility to create FSM orders directly from the CRM form through a wizard.
It simplifies the creation of FSM orders from leads, and it will automatically create the customer's FSM location if it does not already exist.

cc https://github.com/APSL 3932

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review