### PR TITLE
[17.0][FIX]  fieldservice_geoengine: Remove widget for shape field

### DIFF
--- a/fieldservice_geoengine/views/fsm_location.xml
+++ b/fieldservice_geoengine/views/fsm_location.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="fieldservice.fsm_location_form_view" />
         <field name="arch" type="xml">
             <group id="get_locate" position="before">
-                <field name='shape' widget="geo_edit_map" />
+                <field name="shape" />
             </group>
         </field>
     </record>


### PR DESCRIPTION
   Porting of PR [#1324](https://github.com/OCA/field-service/pull/1324)

   Widget "geo_edit_map" is not required as field type "GeoPoint" is used to identify the same. So, widget is removed from "shape" field.