### PR TITLE
[15.0][IMP] fieldservice_sale: Show FSM Orders button for own documents users

### DIFF
--- a/fieldservice_sale/views/sale_order.xml
+++ b/fieldservice_sale/views/sale_order.xml
@@ -3,7 +3,7 @@
         <field name="name">sale.order.form.sale.fieldservice</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form" />
-        <field name="groups_id" eval="[(4, ref('fieldservice.group_fsm_user'))]" />
+        <field name="groups_id" eval="[(4, ref('fieldservice.group_fsm_user_own'))]" />
         <field name="arch" type="xml">
             <xpath expr="//button[@name='action_view_invoice']" position="before">
                 <button
@@ -12,7 +12,6 @@
                     class="oe_stat_button"
                     icon="fa-map"
                     attrs="{'invisible': [('fsm_order_count', '=', 0)]}"
-                    groups="fieldservice.group_fsm_user"
                 >
                     <field
                         name="fsm_order_count"


### PR DESCRIPTION
The `FSM Orders` button wasn't visible in the Sale Order view for `group_fsm_user_own` users.
This [IMP] makes the button accessible, aligning it with the group's access rights.

cc https://github.com/APSL 3553

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador please review