### PR TITLE
[FIX] fieldservice: display html in order report

### DIFF
--- a/fieldservice/report/fsm_order_report_template.xml
+++ b/fieldservice/report/fsm_order_report_template.xml
@@ -41,7 +41,7 @@
                 </div>
                 <div t-if="doc.todo" id="instruction">
                     <h3>Instructions</h3>
-                    <p t-out="doc.todo" />
+                    <p t-raw="doc.todo" />
                 </div>
                 <div t-if="doc.resolution" id="resolution">
                     <h3>Resolution Notes</h3>


### PR DESCRIPTION
Fixes the printable FSM Order report so that HTML is rendered properly for the order instructions section

Before:
![image](https://github.com/user-attachments/assets/2e6e5761-0c96-4411-9fde-aa6606d399f5)
