### PR TITLE
[17.0][IMP] fieldservice_crm: Added more filters on fsm_orders

### DIFF
--- a/fieldservice_crm/i18n/es.po
+++ b/fieldservice_crm/i18n/es.po
@@ -6,11 +6,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-05 09:16+0000\n"
-"PO-Revision-Date: 2025-03-05 09:16+0000\n"
+"POT-Creation-Date: 2025-03-13 07:08+0000\n"
+"PO-Revision-Date: 2025-03-13 07:08+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -27,6 +26,11 @@ msgid "# Opportunities"
 msgstr "# Oportunidades"
 
 #. module: fieldservice_crm
+#: model_terms:ir.ui.view,arch_db:fieldservice_crm.fsm_order_crm_kanban_view
+msgid "<i class=\"fa fa-dollar me-2 fa-lg\" title=\"Salesperson\"/>"
+msgstr "<i class=\"fa fa-dollar me-2 fa-lg\" title=\"Comercial\"/>"
+
+#. module: fieldservice_crm
 #: model_terms:ir.ui.view,arch_db:fieldservice_crm.fieldservice_crm_form_view
 msgid "Create FS Order"
 msgstr "Crear Orden FS"
@@ -37,6 +41,11 @@ msgstr "Crear Orden FS"
 #, python-format
 msgid "Create FSM Order"
 msgstr "Crear Orden FSM"
+
+#. module: fieldservice_crm
+#: model:ir.model.fields,field_description:fieldservice_crm.field_fsm_order__opportunity_customer_vat
+msgid "Customer VAT"
+msgstr "NIF del cliente"
 
 #. module: fieldservice_crm
 #: model_terms:ir.ui.view,arch_db:fieldservice_crm.fieldservice_crm_form_view
@@ -79,6 +88,11 @@ msgstr "Oportunidad"
 #, python-format
 msgid "Please select a customer."
 msgstr "Por favor seleccione un cliente."
+
+#. module: fieldservice_crm
+#: model:ir.model.fields,field_description:fieldservice_crm.field_fsm_order__sales_person_id
+msgid "Salesperson"
+msgstr "Comercial"
 
 #. module: fieldservice_crm
 #: model:ir.model.fields,field_description:fieldservice_crm.field_crm_lead__fsm_order_ids

--- a/fieldservice_crm/models/fsm_order.py
+++ b/fieldservice_crm/models/fsm_order.py
@@ -1,10 +1,43 @@
 # Copyright (C) 2019, Patrick Wilson
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class FSMOrder(models.Model):
     _inherit = "fsm.order"
 
     opportunity_id = fields.Many2one("crm.lead", tracking=True)
+    opportunity_customer_vat = fields.Char(
+        related="opportunity_id.partner_id.vat", string="Customer VAT"
+    )
+    sales_person_id = fields.Many2one(
+        "res.users",
+        compute="_compute_sales_person_id",
+        string="Salesperson",
+        readonly=False,
+        store=True,
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        if self._has_dispacher_group():
+            for vals in vals_list:
+                if not vals.get("opportunity_id") and not vals.get("sales_person_id"):
+                    vals["sales_person_id"] = self.env.user.id
+        return super().create(vals_list)
+
+    @api.depends("opportunity_id", "opportunity_id.user_id")
+    def _compute_sales_person_id(self):
+        has_dispacher_group = self._has_dispacher_group()
+        for order in self:
+            if order.opportunity_id and order.opportunity_id.user_id:
+                order.sales_person_id = order.opportunity_id.user_id
+            elif not order.sales_person_id:
+                if has_dispacher_group:
+                    order.sales_person_id = self.env.user
+                else:
+                    order.sales_person_id = False
+
+    def _has_dispacher_group(self):
+        return self.env.user.has_group("fieldservice.group_fsm_dispatcher")

--- a/fieldservice_crm/tests/test_fsm_crm.py
+++ b/fieldservice_crm/tests/test_fsm_crm.py
@@ -9,33 +9,41 @@ class TestFieldserviceCrm(common.TransactionCase):
     def setUpClass(cls):
         cls._super_send = requests.Session.send
         super().setUpClass()
-
-    def test_fieldservicecrm(self):
-        location_1 = self.env["fsm.location"].create(
+        cls.location_1 = cls.env["fsm.location"].create(
             {
                 "name": "Summer's House",
-                "owner_id": self.env["res.partner"]
+                "owner_id": cls.env["res.partner"]
                 .create({"name": "Summer's Parents"})
                 .id,
             }
         )
+
+        cls.fsm_user = cls.env["res.users"].create(
+            {
+                "name": "Fsm User",
+                "login": "fsm_user",
+                "groups_id": [(6, 0, [cls.env.ref("fieldservice.group_fsm_user").id])],
+            }
+        )
+
+    def test_fieldservicecrm(self):
         crm_1 = self.env["crm.lead"].create(
             {
                 "name": "Test CRM",
-                "fsm_location_id": location_1.id,
+                "fsm_location_id": self.location_1.id,
             }
         )
         self.env["fsm.order"].create(
             {
-                "location_id": location_1.id,
+                "location_id": self.location_1.id,
                 "opportunity_id": crm_1.id,
             }
         )
         crm_1._compute_fsm_order_count()
         self.assertEqual(crm_1.fsm_order_count, 1)
 
-        location_1._compute_opportunity_count()
-        self.assertEqual(location_1.opportunity_count, 1)
+        self.location_1._compute_opportunity_count()
+        self.assertEqual(self.location_1.opportunity_count, 1)
 
     # Needed to avoid conflicts with fieldservice_geoengine when it's installed
     @classmethod
@@ -71,3 +79,39 @@ class TestFieldserviceCrm(common.TransactionCase):
         )
         with self.assertRaises(UserError):
             crm_1.create_fsm_order()
+
+    def test_compute_sales_person_id_01(self):
+        partner_1 = self.env["res.partner"].create(
+            {
+                "name": "Test partner",
+                "street": "123 Test St",
+                "city": "Test City",
+                "zip": "12345",
+                "country_id": self.env.ref("base.us").id,
+            }
+        )
+        crm_1 = self.env["crm.lead"].create(
+            {
+                "name": "Test CRM",
+                "partner_id": partner_1.id,
+                "user_id": self.env.user.id,
+            }
+        )
+
+        self.env["fsm.order"].create(
+            {
+                "location_id": self.location_1.id,
+                "opportunity_id": crm_1.id,
+            }
+        )
+        self.assertEqual(crm_1.user_id, crm_1.fsm_order_ids[0].sales_person_id)
+
+    def test_compute_sales_person_id_02(self):
+        fsm_order_1 = self.env["fsm.order"].create(
+            {
+                "name": "Test FSM Order",
+                "location_id": self.location_1.id,
+            }
+        )
+
+        self.assertEqual(fsm_order_1.sales_person_id, self.env.user)

--- a/fieldservice_crm/views/fsm_order.xml
+++ b/fieldservice_crm/views/fsm_order.xml
@@ -18,6 +18,10 @@
         <field name="arch" type="xml">
             <field name="priority" position="before">
                 <field name="opportunity_id" />
+                <field
+                    name="sales_person_id"
+                    groups="fieldservice.group_fsm_dispatcher"
+                />
             </field>
         </field>
     </record>
@@ -28,7 +32,45 @@
         <field name="arch" type="xml">
             <field name="person_ids" position="after">
                 <field name="opportunity_id" />
+                <field
+                    name="opportunity_customer_vat"
+                    filter_domain="[('opportunity_customer_vat', 'ilike', self)]"
+                />
+                <field
+                    name="sales_person_id"
+                    filter_domain="[('sales_person_id', 'ilike', self)]"
+                />
             </field>
         </field>
     </record>
+
+    <record id="fsm_order_crm_kanban_view" model="ir.ui.view">
+        <field name="name">fsm.order.crm.kanban</field>
+        <field name="model">fsm.order</field>
+        <field name="inherit_id" ref="fieldservice.fsm_order_kanban_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('o_kanban_record_bottom')]" position="before">
+                <div invisible="not sales_person_id">
+                    <i class="fa fa-dollar me-2 fa-lg" title="Salesperson" />
+                    <field name="sales_person_id" />
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="fsm_order_crm_calendar_view" model="ir.ui.view">
+        <field name="name">fsm.order.crm.calendar</field>
+        <field name="model">fsm.order</field>
+        <field name="inherit_id" ref="fieldservice.fsm_order_calendar_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='location_id']" position="after">
+                <field
+                    name="sales_person_id"
+                    filters="1"
+                    invisible="not sales_person_id"
+                />
+            </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
This PR introduces additional filters for fsm_orders, enhancing the search functionality.

New Features:
Search by Customer VAT: Easily locate orders using the customer's VAT number.
Search by Salesperson: Filter orders based on the assigned salesperson.
Salesperson in Kanban View: The salesperson is now displayed in the Kanban view for better visibility.
Salesperson Filter in Calendar View: Added a filter in the calendar view.

cc https://github.com/APSL 4230

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review