### PR TITLE
[16.0][IMP] fieldservice: Define @freeze_time decorator in tests and not in TestFSMOrderBase to avoid side effects

### DIFF
--- a/fieldservice/tests/test_fsm_order.py
+++ b/fieldservice/tests/test_fsm_order.py
@@ -9,7 +9,6 @@ from odoo.exceptions import UserError, ValidationError
 from odoo.tests.common import Form, TransactionCase
 
 
-@freeze_time("2023-02-01")
 class TestFSMOrderBase(TransactionCase):
     def setUp(self):
         super().setUp()
@@ -118,6 +117,7 @@ class TestFSMOrderBase(TransactionCase):
 
 
 class TestFSMOrder(TestFSMOrderBase):
+    @freeze_time("2023-02-01")
     def test_fsm_order(self):
         """Test creating new workorders, and test following functions,
         - _compute_duration() in hrs


### PR DESCRIPTION
Define `@freeze_time` decorator in tests and not in TestFSMOrderBase to avoid side effects

If a module has a test that extends it, a crash occurs in post tests

Related to https://github.com/OCA/field-service/pull/1340#issuecomment-2711247458

@Tecnativa