### PR TITLE
[17.0][IMP] fieldservice: Added filter Due This Week

### DIFF
--- a/fieldservice/i18n/es.po
+++ b/fieldservice/i18n/es.po
@@ -1080,6 +1080,11 @@ msgstr "Hecho"
 
 #. module: fieldservice
 #: model_terms:ir.ui.view,arch_db:fieldservice.fsm_order_search_view
+msgid "Due This Week"
+msgstr "Para esta semana"
+
+#. module: fieldservice
+#: model_terms:ir.ui.view,arch_db:fieldservice.fsm_order_search_view
 msgid "Due Within 30 Days"
 msgstr "Pagado Dentro de 30 Días"
 

--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -402,6 +402,12 @@
                     ]"
                     name="order_upcoming_month"
                 />
+                <filter
+                    string="Due This Week"
+                    name="this_week_orders"
+                    domain="[('scheduled_date_start', '&lt;=', ((context_today()+relativedelta(weeks=0, weekday=-1)).strftime('%Y-%m-%d'))),
+                    ('scheduled_date_start', '&gt;=', ((context_today()-relativedelta(weeks=1, weekday=0)).strftime('%Y-%m-%d')))]"
+                />
                 <separator />
                 <group expand="0" string="Group By">
                     <filter


### PR DESCRIPTION
This PR introduces a filter on fsm_order to display orders that are scheduled for completion within the current week (from Monday to Sunday). The filter ensures that only orders with a scheduled_date_start within this week are shown.

cc https://github.com/APSL 4230

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review