### PR TITLE
[15.0][IMP] fieldservice_activity: Use @freeze_time for time-sensitive tests

### DIFF
--- a/fieldservice_activity/tests/test_fsm_activity.py
+++ b/fieldservice_activity/tests/test_fsm_activity.py
@@ -2,6 +2,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from datetime import datetime
 
+from freezegun import freeze_time
+
 from odoo.exceptions import ValidationError
 from odoo.tests.common import Form, TransactionCase
 
@@ -36,6 +38,7 @@ class TestFSMActivity(TransactionCase):
             }
         )
 
+    @freeze_time("2025-03-19")
     def test_fsm_activity(self):
         """Test creating new activites, and moving them along thier stages,
         - Don't move FSM Order to complete if Required Activity in 'To Do'


### PR DESCRIPTION
When trying to merge #1348 we got an error on this [line](https://github.com/OCA/field-service/blob/15.0/fieldservice_activity/tests/test_fsm_activity.py#L82) due to a one second difference:

`2025-03-17 15:43:02,000 410 ERROR odoo odoo.addons.fieldservice_activity.tests.test_fsm_activity: FAIL: TestFSMActivity.test_fsm_activity Traceback (most recent call last): File "/__w/field-service/field-service/fieldservice_activity/tests/test_fsm_activity.py", line 82, in test_fsm_activity self.assertEqual( AssertionError: datetime.datetime(2025, 3, 17, 15, 43, 1) != datetime.datetime(2025, 3, 17, 15, 43, 2)`

This PR prevents such failures by adding the `@freeze_time` decorator to `test_fsm_activity` method.