### PR TITLE
[17.0][IMP] fieldservice_recurring:  Add access rules and permissions for fsm_frequency, fms_frequency_set, fsm_recurring_template and fsm_recurring

### DIFF
--- a/fieldservice_recurring/security/ir.model.access.csv
+++ b/fieldservice_recurring/security/ir.model.access.csv
@@ -1,9 +1,13 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_fsm_frequency_fsm_user_own,fsm.frequency.user.own,model_fsm_frequency,fieldservice.group_fsm_user_own,1,1,1,0
 access_fsm_frequency_fsm_user,fsm.frequency.user,model_fsm_frequency,fieldservice.group_fsm_user,1,1,1,0
 access_fsm_frequency_fsm_manager,fsm.frequency.manager,model_fsm_frequency,fieldservice.group_fsm_manager,1,1,1,1
+access_fsm_frequency_fsm_set_user_own,fsm.frequency.set.user.own,model_fsm_frequency_set,fieldservice.group_fsm_user_own,1,1,1,0
 access_fsm_frequency_fsm_set_user,fsm.frequency.set.user,model_fsm_frequency_set,fieldservice.group_fsm_user,1,1,1,0
 access_fsm_frequency_fsm_set_manager,fsm.frequency.set.manager,model_fsm_frequency_set,fieldservice.group_fsm_manager,1,1,1,1
+access_fsm_recurring_template_fsm_user_own,fsm.recurring.template.user.own,model_fsm_recurring_template,fieldservice.group_fsm_user_own,1,0,0,0
 access_fsm_recurring_template_fsm_user,fsm.recurring.template.user,model_fsm_recurring_template,fieldservice.group_fsm_user,1,0,0,0
 access_fsm_recurring_template_fsm_manager,fsm.recurring.template.manager,model_fsm_recurring_template,fieldservice.group_fsm_manager,1,1,1,1
+access_fsm_recurring_fsm_user_own,fsm.recurring.user.own,model_fsm_recurring,fieldservice.group_fsm_user_own,1,1,1,0
 access_fsm_recurring_fsm_user,fsm.recurring.user,model_fsm_recurring,fieldservice.group_fsm_user,1,1,1,0
 access_fsm_recurring_fsm_manager,fsm.recurring.manager,model_fsm_recurring,fieldservice.group_fsm_manager,1,1,1,1

--- a/fieldservice_recurring/security/recurring_security.xml
+++ b/fieldservice_recurring/security/recurring_security.xml
@@ -24,4 +24,19 @@
             name="domain_force"
         >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
     </record>
+    <record id="fsm_recurring_own_rule" model="ir.rule">
+        <field name="name">FSM Recurring Entry (only own)</field>
+        <field name="model_id" ref="model_fsm_recurring" />
+        <field
+            name="domain_force"
+        >['|',('person_id.user_ids','=',user.id),('person_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('fieldservice.group_fsm_user_own'))]" />
+    </record>
+    <record id="fsm_recurring_user" model="ir.rule">
+        <field name="name">FSM Recurring Entry</field>
+        <field name="model_id" ref="model_fsm_recurring" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('fieldservice.group_fsm_user'))]" />
+    </record>
+
 </odoo>

--- a/fieldservice_recurring/security/res_groups.xml
+++ b/fieldservice_recurring/security/res_groups.xml
@@ -5,7 +5,7 @@
         <field name="name">Manage Recurring Orders</field>
         <field name="category_id" ref="base.module_category_hidden" />
     </record>
-    <record id="fieldservice.group_fsm_user" model="res.groups">
+    <record id="fieldservice.group_fsm_user_own" model="res.groups">
         <field
             name="implied_ids"
             eval="[(4, ref('fieldservice_recurring.group_fsm_recurring'))]"


### PR DESCRIPTION
When managing fsm_frequency, fms_frequency_set, fsm_recurring_template and fsm_recurring records with the "User Own" group, I wasn't able to access any of the records. This IMP adds access rules to ensure "User Own" members see only their assigned records, while managers have full access.

cc https://github.com/APSL 6216
@miquelalzanillas @javierobcn @mpascuall @BernatObrador @ppyczko @lbarry-apsl please review