### PR TITLE
[16.0][IMP] fieldservice_geoengine: Show warning to user

### DIFF
--- a/fieldservice_geoengine/views/fsm_location.xml
+++ b/fieldservice_geoengine/views/fsm_location.xml
@@ -8,6 +8,20 @@
             <group id="get_locate" position="before">
                 <field name="shape" />
             </group>
+            <xpath expr="//sheet/label" position="before">
+                <field name="partner_latitude" invisible="1" />
+                <field name="partner_longitude" invisible="1" />
+                <div
+                    class="alert alert-warning text-center"
+                    role="alert"
+                    attrs="{'invisible':['|', ('partner_latitude','!=',0), ('partner_longitude', '!=', 0)]}"
+                    style="margin-bottom:0px;"
+                >
+                    <p
+                        class="fa fa-warning"
+                    >&amp;nbsp;Update Latitude and Longitude details accordingly!</p>
+                </div>
+            </xpath>
         </field>
     </record>
     <!-- GeoEngine views -->


### PR DESCRIPTION
   Introduced "warning" to be displayed in "fsm.location" form view when value of latitude or longitude details is not available.
   
   This also helps to resolve below error which is displayed with "geoengine" view while clicking Locations from recordPanel which is observed when latitude and longitude details is not available.
   
    
![Screenshot from 2025-03-10 13-35-45](https://github.com/user-attachments/assets/3cf470bf-9c18-4ec0-83fb-330ccedcbb5e)
