### PR TITLE
[15.0][FIX] fieldservice_route: Allow FSM own users to see all routes and assigned orders

### DIFF
--- a/fieldservice_route/security/ir_rule.xml
+++ b/fieldservice_route/security/ir_rule.xml
@@ -4,17 +4,8 @@
   <record id="fsm_route_own_rule" model="ir.rule">
     <field name="name">FSM Routes Entry (only own)</field>
     <field name="model_id" ref="model_fsm_route" />
-    <field
-            name="domain_force"
-        >['|',('fsm_person_id.user_ids','=',user.id),('fsm_person_id','=',False)]</field>
-    <field name="groups" eval="[(4, ref('fieldservice.group_fsm_user_own'))]" />
-  </record>
-
-  <record id="fsm_route_user" model="ir.rule">
-    <field name="name">FSM Routes Entry</field>
-    <field name="model_id" ref="model_fsm_route" />
     <field name="domain_force">[(1, '=', 1)]</field>
-    <field name="groups" eval="[(4, ref('fieldservice.group_fsm_user'))]" />
+    <field name="groups" eval="[(4, ref('fieldservice.group_fsm_user_own'))]" />
   </record>
 
   <record id="fsm_route_dayroute_own_rule" model="ir.rule">


### PR DESCRIPTION
For a user with the `fieldservice.group_fsm_user_own` group, if an FSM order was assigned to them but the route linked to that order was assigned to a different person, an access error occurred. This PR ensures that users can access their assigned FSM orders regardless of the person assigned to the route.

cc https://github.com/APSL 6225

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador please review