### PR TITLE
[15.0][IMP] fieldservice_portal: Display location address, scheduled date and date end

### DIFF
--- a/fieldservice_portal/views/fsm_order_template.xml
+++ b/fieldservice_portal/views/fsm_order_template.xml
@@ -37,6 +37,7 @@
                                 <th>Name</th>
                                 <th>Description</th>
                                 <th>Location</th>
+                                <th>Scheduled Date</th>
                                 <th>Type</th>
                                 <th>Stage</th>
                             </tr>
@@ -55,6 +56,11 @@
                                     <td>
                                         <t
                                             t-out="fsm_order.sudo().location_id.display_name"
+                                        />
+                                    </td>
+                                    <td>
+                                        <span
+                                            t-field="fsm_order.scheduled_date_start"
                                         />
                                     </td>
                                     <td>
@@ -88,6 +94,12 @@
                                 <strong>Location:</strong>
                                 <span t-field="fsm_order.location_id" />
                                 <br />
+                                <strong>
+                                Address:</strong>
+                                <span t-field="fsm_order.location_id.street" />, <span
+                                    t-field="fsm_order.location_id.street2"
+                                />
+                                <br />
                                 <strong>City:</strong>
                                 <span t-field="fsm_order.location_id.city" />
                                 <t t-if="fsm_order.location_id.state_id">
@@ -116,12 +128,27 @@
                                     <span>N/A</span>
                                 </t>
                                 <br />
-                                <strong>Arrival On Site:</strong>
+                                <strong>Scheduled Date:</strong>
+                                <t t-if="fsm_order.scheduled_date_start">
+                                    <span t-field="fsm_order.scheduled_date_start" />
+                                </t>
+                                <t t-else="">
+                                    <span>N/A</span>
+                                </t>
+                                <br />
+                                <strong>Actual Start:</strong>
                                 <span
                                     t-if="fsm_order.date_start"
                                     t-field="fsm_order.date_start"
                                 />
                                 <span t-else="">Not started yet</span>
+                                <br />
+                                <strong>Actual End:</strong>
+                                <span
+                                    t-if="fsm_order.date_end"
+                                    t-field="fsm_order.date_end"
+                                />
+                                <span t-else="">Not completed yet</span>
                                 <br />
                             </div>
                         </div>


### PR DESCRIPTION
This update enhances the portal view for FSM orders by adding the location's address and the scheduled date. Additionally, the "Arrival On Site" (date_start) and "Completion Date" (date_end) fields will now only be displayed when they are filled in, helping to reduce clutter and improve the user experience.

cc https://github.com/APSL 6228

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador please review