### PR TITLE
[FIX] fieldservice_sale: fix broken links in FSM order messages

### DIFF
--- a/fieldservice_sale/models/sale_order.py
+++ b/fieldservice_sale/models/sale_order.py
@@ -187,20 +187,16 @@ class SaleOrder(models.Model):
         Post messages to the Sale Order and the newly created FSM Orders
         """
         self.ensure_one()
-        msg_fsm_links = ""
         for fsm_order in fsm_orders:
-            fsm_order.message_mail_with_source(
+            fsm_order.message_post_with_source(
                 "mail.message_origin_link",
                 render_values={"self": fsm_order, "origin": self},
-                subtype_id=self.env.ref("mail.mt_note").id,
-                author_id=self.env.user.partner_id.id,
+                subtype_xmlid="mail.mt_note",
             )
-            msg_fsm_links += (
-                " <a href=# data-oe-model=fsm.order data-oe-id={}>{}</a>,".format(
-                    fsm_order.id, fsm_order.name
-                )
-            )
-        so_msg_body = _("Field Service Order(s) Created: %s", msg_fsm_links)
+        so_msg_body = _(
+            "Field Service Order(s) Created: %s",
+            fsm_order._get_html_link(title=fsm_order.name),
+        )
         self.message_post(body=so_msg_body[:-1])
 
     def _action_confirm(self):


### PR DESCRIPTION
When confirming a sale order that will generate FSM Orders, the messages logged on both sale order and FSM order have broken links

Sale Order message
![Screenshot_20250327_103954](https://github.com/user-attachments/assets/6aea860a-4f7a-4ef2-8e85-d7068b97a475)

FSM Order message
Click this link but sale order is not found
![Screenshot_20250327_104019](https://github.com/user-attachments/assets/458c23a7-2bc3-4c9f-b552-a629b93b1e0f)
