### PR TITLE
[15.0][IMP] fieldservice_route: Add many2many_tags widget to day_ids

### DIFF
--- a/fieldservice_route/views/fsm_route.xml
+++ b/fieldservice_route/views/fsm_route.xml
@@ -7,7 +7,7 @@
             <tree>
                 <field name="name" />
                 <field name="fsm_person_id" />
-                <field name="day_ids" />
+                <field name="day_ids" widget="many2many_tags" />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
This PR adds the `many2many_tags` widget to the `day_ids` field to quickly view the assigned days at a glance.

Before:
![image](https://github.com/user-attachments/assets/aa006368-089b-499f-ba68-bea602e16d3f)

After:
![image](https://github.com/user-attachments/assets/5330ff92-b632-4dec-b207-1b573715e06d)

cc https://github.com/APSL 7063

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador please review
