### PR TITLE
[17.0][FIX] fieldservice_stock_request: process all records in _action_confirm

### DIFF
--- a/fieldservice_stock_request/models/stock_request.py
+++ b/fieldservice_stock_request/models/stock_request.py
@@ -170,8 +170,5 @@ class StockRequest(models.Model):
                 if req.order_id:
                     req.order_id.procurement_group_id = group.id
                 req.procurement_group_id = group.id
-                res = super(StockRequest, req)._action_confirm()
                 req.fsm_order_id.request_stage = "open"
-            else:
-                res = super(StockRequest, req)._action_confirm()
-            return res
+        return super()._action_confirm()


### PR DESCRIPTION
Before this fix, the _action_confirm method incorrectly returned inside a for loop, causing only the first stock request record to be processed and skipping the rest. This resulted in only one request moving to the 'on process' state, while the others remained stuck in 'submitted', and pickings were not created for all requests.

Now, when confirming a request order, all related stock requests will be properly processed.

cc https://github.com/APSL 8361

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review