### PR TITLE
[17.0][IMP] fieldservice_stock: Autocomplete order warehouse with default worker warehouse

### DIFF
--- a/fieldservice_stock/README.rst
+++ b/fieldservice_stock/README.rst
@@ -51,14 +51,14 @@ Configuration
 
 To configure this module, you need to:
 
-- Go to Field Service > Master Data > Locations
-- Create or select a location and set the inventory location
+-  Go to Field Service > Master Data > Locations
+-  Create or select a location and set the inventory location
 
 If you are in a multi-warehouse situation:
 
-- Go to Field Service > Configuration > Territories
-- Create or select a territory
-- Set the warehouse that will serve this territory
+-  Go to Field Service > Configuration > Territories
+-  Create or select a territory
+-  Set the warehouse that will serve this territory
 
 Usage
 =====
@@ -94,18 +94,18 @@ Authors
 Contributors
 ------------
 
-- Brian McMaster <brian@mcmpest.com>
-- Sandip Mangukiya <smangukiya@opensourceintegrators.com>
-- Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
-- Marcel Savegnago <marcel.savegnago@escodoo.com.br>
-- Freni Patel <fpatel@opensourceintegrators.com>
+-  Brian McMaster <brian@mcmpest.com>
+-  Sandip Mangukiya <smangukiya@opensourceintegrators.com>
+-  Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+-  Marcel Savegnago <marcel.savegnago@escodoo.com.br>
+-  Freni Patel <fpatel@opensourceintegrators.com>
 
 Other credits
 -------------
 
 The development of this module has been financially supported by:
 
-- Open Source Integrators <https://opensourceintegrators.com>
+-  Open Source Integrators <https://opensourceintegrators.com>
 
 Maintainers
 -----------

--- a/fieldservice_stock/__manifest__.py
+++ b/fieldservice_stock/__manifest__.py
@@ -19,6 +19,7 @@
         "views/fsm_order.xml",
         "views/stock.xml",
         "views/stock_picking.xml",
+        "views/fsm_person.xml",
     ],
     "pre_init_hook": "_pre_init_hook",
     "license": "AGPL-3",

--- a/fieldservice_stock/models/__init__.py
+++ b/fieldservice_stock/models/__init__.py
@@ -10,4 +10,5 @@ from . import (
     stock_rule,
     stock_picking,
     fsm_wizard,
+    fsm_person,
 )

--- a/fieldservice_stock/models/fsm_order.py
+++ b/fieldservice_stock/models/fsm_order.py
@@ -56,6 +56,17 @@ class FSMOrder(models.Model):
             order.return_count = len(incoming_pickings.ids)
             order.move_ids = order.picking_ids.mapped("move_ids")
 
+    @api.onchange("person_id")
+    def _onchange_person_id(self):
+        # Autofill the worker deafault warehouse if has one
+        completed_stage = self.env.ref("fieldservice.fsm_stage_completed")
+        for order in self:
+            if order.stage_id.id == completed_stage.id:
+                continue
+            if order.person_id and order.person_id.default_warehouse_id:
+                order.warehouse_id = order.person_id.default_warehouse_id
+        return super()._onchange_person_id()
+
     def action_view_delivery(self):
         """
         This function returns an action that display existing delivery orders

--- a/fieldservice_stock/models/fsm_person.py
+++ b/fieldservice_stock/models/fsm_person.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class FSMPerson(models.Model):
+    _inherit = "fsm.person"
+
+    default_warehouse_id = fields.Many2one(
+        "stock.warehouse",
+        string="Default Warehouse",
+        help="Default warehouse for this worker",
+    )

--- a/fieldservice_stock/views/fsm_person.xml
+++ b/fieldservice_stock/views/fsm_person.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_fsm_person_form_inherit" model="ir.ui.view">
+        <field name="name">view.fsm.person.from.inhetir</field>
+        <field name="model">fsm.person</field>
+        <field name="inherit_id" ref="fieldservice.fsm_person_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='calendar_id']" position="after">
+                <field name="default_warehouse_id" />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This PR adds autocomplete for the warehouse_id in FSM orders based on the worker’s default warehouse.

How to test:
1. Create an additional warehouse (if the company only has one).
2. Go to the worker in field service and set the Default Warehouse
3. In an FSM order, select the worker.
4. The warehouse_id field should autopopulate with the worker default warehouse.

cc https://github.com/APSL 8334

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review