### PR TITLE
[17.0][IMP] fieldservice: Improve partner location creation with new partner

### DIFF
--- a/fieldservice/models/fsm_location.py
+++ b/fieldservice/models/fsm_location.py
@@ -25,7 +25,6 @@ class FSMLocation(models.Model):
     owner_id = fields.Many2one(
         "res.partner",
         string="Related Owner",
-        required=True,
         ondelete="restrict",
         auto_join=True,
     )

--- a/fieldservice/views/fsm_location.xml
+++ b/fieldservice/views/fsm_location.xml
@@ -102,12 +102,7 @@
                         <group id="main-left">
                             <field name="id" invisible="1" />
                             <field name="fsm_parent_id" domain="[('id', '!=', id)]" />
-                            <field
-                                name="partner_id"
-                                groups="base.group_no_one"
-                                readonly="1"
-                                required="0"
-                            />
+                            <field name="partner_id" />
                             <field name="owner_id" />
                             <field
                                 name="contact_id"


### PR DESCRIPTION
In the creation of partner location the field `partner_id` is readonly in form view and you can't create a new partner from that view.
This improvement remove the required  `owner_id` field and put the required on `partner_id` that can create partner from the same screen without changing the application or the view.

cc https://github.com/APSL 1811
@miquelalzanillas @javierobcn @mpascuall @BernatObrador @ppyczko @lbarry-apsl please review