### PR TITLE
[17.0][IMP] fieldservice: Display stages in calendar using their stage color

### DIFF
--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -459,7 +459,7 @@
                 string="FSM Orders"
                 date_start="scheduled_date_start"
                 date_delay="scheduled_duration"
-                color="stage_id"
+                color="custom_color"
             >
                 <field name="name" />
                 <field name="stage_id" filters="1" />


### PR DESCRIPTION
This improvement changes how order colors are displayed in the calendar view.
Orders now use the color of their respective stage, making the calendar view more flexible and configurable.
This approach also allows users to customize stage colors, offering better visual management in the calendar.

cc https://github.com/APSL 9157

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn please review