### PR TITLE
[17.0][FIX] fieldservice_vehicle: Fixed permissions for user own documents

### DIFF
--- a/fieldservice_vehicle/security/ir.model.access.csv
+++ b/fieldservice_vehicle/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_fsm_vehicle_fsm_user,fsm.vehicle.user,model_fsm_vehicle,fieldservice.group_fsm_user,1,0,0,0
+access_fsm_vehicle_fsm_user,fsm.vehicle.user,model_fsm_vehicle,fieldservice.group_fsm_user_own,1,0,0,0
 access_fsm_vehicle_fsm_manager,fsm.vehicle.manager,model_fsm_vehicle,fieldservice.group_fsm_manager,1,1,1,1


### PR DESCRIPTION
This PR corrects the permissions for fsm_vehicle to grant users in the 'Own Documents' group access to vehicles.

cc https://github.com/APSL 9161

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn please review

