### PR TITLE
[FIX] fieldservice_vehicle: Fix onchange person_id

### DIFF
--- a/fieldservice_vehicle/models/fsm_order.py
+++ b/fieldservice_vehicle/models/fsm_order.py
@@ -29,3 +29,4 @@ class FSMOrder(models.Model):
             and self.person_id.vehicle_id.id
             or False
         )
+        return super()._onchange_person_id()


### PR DESCRIPTION
When person_id change the team is not setting.
When override the onchange method you need to call super for make the inherit functions from the basic module working. See the code below:
https://github.com/OCA/field-service/blob/17.0/fieldservice/models/fsm_order.py#L400

#1387 
cc https://github.com/APSL 9530
@miquelalzanillas @lbarry-apsl @javierobcn @mpascuall @BernatObrador @ppyczko please review

