### PR TITLE
[15.0][FIX] fieldservice_sale: avoid singleton error in _field_service_generation

### DIFF
--- a/fieldservice_sale/models/sale_order.py
+++ b/fieldservice_sale/models/sale_order.py
@@ -172,7 +172,7 @@ class SaleOrder(models.Model):
         created_fsm_orders = self.env["fsm.order"]
 
         for sale in self:
-            new_fsm_orders = self._field_service_generate()
+            new_fsm_orders = sale._field_service_generate()
 
             if len(new_fsm_orders) > 0:
                 created_fsm_orders |= new_fsm_orders


### PR DESCRIPTION
This PR fixes a singleton error when generating field service orders from multiple sale orders.

cc https://github.com/APSL 9930

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador please review