### PR TITLE
[15.0][FIX] fieldservice_sale_stock_route: Fix FSM delivery postponement to skip current route day

### DIFF
--- a/fieldservice_sale_stock_route/models/fsm_order.py
+++ b/fieldservice_sale_stock_route/models/fsm_order.py
@@ -36,7 +36,7 @@ class FSMOrder(models.Model):
         for fsm_order in self.filtered(self._is_valid_fsm_order):
             sale_order = fsm_order.sale_id
             new_commitment_date = sale_order._get_next_route_day(
-                from_date=sale_order.commitment_date
+                from_date=sale_order.commitment_date + timedelta(days=1)
             )
             date_diff = (new_commitment_date - sale_order.commitment_date).days
 

--- a/fieldservice_sale_stock_route/tests/test_fieldservice_sale_stock_route.py
+++ b/fieldservice_sale_stock_route/tests/test_fieldservice_sale_stock_route.py
@@ -177,7 +177,9 @@ class TestFieldServiceSaleStockRoute(TransactionCase):
             "Postpone button should be visible after confirmation.",
         )
 
-        next_route_day = self.sale_order._get_next_route_day()
+        next_route_day = self.sale_order._get_next_route_day(
+            from_date=self.sale_order.commitment_date + timedelta(days=1)
+        )
         related_fsm_order.action_postpone_delivery()
 
         self.assertEqual(


### PR DESCRIPTION
This PR aims to ensure that postponed FSM deliveries are scheduled for the next valid route day, rather than remaining on the current one.

cc https://github.com/APSL 9930

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador please review