### PR TITLE
[15.0][FIX] fieldservice_sale_stock_route: Use @freeze_time for time-sensitive tests

### DIFF
--- a/fieldservice_sale_stock_route/tests/test_fieldservice_sale_stock_route.py
+++ b/fieldservice_sale_stock_route/tests/test_fieldservice_sale_stock_route.py
@@ -3,6 +3,8 @@
 
 from datetime import datetime, timedelta
 
+from freezegun import freeze_time
+
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
@@ -44,6 +46,7 @@ class TestFieldServiceSaleStockRoute(TransactionCase):
             }
         )
 
+    @freeze_time("2025-05-15")
     def test_commitment_dates_on_confirmation(self):
         """
         Test that commitment_date and commitment_date_end are correctly
@@ -69,6 +72,7 @@ class TestFieldServiceSaleStockRoute(TransactionCase):
             "Commitment date end should match commitment date after confirmation.",
         )
 
+    @freeze_time("2025-05-15")
     def test_commitment_date_end_before_commitment_date(self):
         """
         Test that commitment_date_end is set to commitment_date if
@@ -112,6 +116,7 @@ class TestFieldServiceSaleStockRoute(TransactionCase):
         with self.assertRaises(ValidationError):
             self.sale_order._action_confirm()
 
+    @freeze_time("2025-05-15")
     def test_write_commitment_dates_to_related_records(self):
         """Test that commitment_date is written to related pickings and FSM orders."""
         next_route_day = self.sale_order._get_next_route_day()
@@ -201,6 +206,7 @@ class TestFieldServiceSaleStockRoute(TransactionCase):
             "and preserve the time.",
         )
 
+    @freeze_time("2025-05-15")
     def test_force_schedule_override(self):
         """
         Test that force_schedule on FSM route allows scheduling on any day.


### PR DESCRIPTION
When trying to merge #1298 we got an error due to a one second difference:

`Traceback (most recent call last):
  File "/__w/field-service/field-service/fieldservice_sale_stock_route/tests/test_fieldservice_sale_stock_route.py", line 60, in test_commitment_dates_on_confirmation
    self.assertEqual(
AssertionError: datetime.datetime(2025, 5, 15, 15, 22, 14) != datetime.datetime(2025, 5, 15, 15, 22, 13) : Commitment date end should match the next route day after confirmation.`

This PR prevents such failures by adding the @freeze_time decorator to all time sensitive tests.

cc https://github.com/APSL 9930

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador please review