### PR TITLE
[17.0][IMP] fieldservice_route: Added routes to calendar view

### DIFF
--- a/fieldservice_route/views/fsm_order.xml
+++ b/fieldservice_route/views/fsm_order.xml
@@ -14,4 +14,15 @@
         </field>
     </record>
 
+    <record id="fsm_order_route_calendar_view" model="ir.ui.view">
+        <field name="name">fsm.order.route.calendar</field>
+        <field name="model">fsm.order</field>
+        <field name="inherit_id" ref="fieldservice.fsm_order_calendar_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='location_id']" position="after">
+                <field name="fsm_route_id" filters="1" invisible="not fsm_route_id" />
+            </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
This PR adds the routes to the field service order calendars view.

It enables to filter by the routes, and see the route of the order in the calendar order view.

cc https://github.com/APSL 9962

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review

