### PR TITLE
[17.0][IMP] fieldservice: Enable search by partner VAT and email

### DIFF
--- a/fieldservice/models/fsm_location.py
+++ b/fieldservice/models/fsm_location.py
@@ -70,6 +70,24 @@ class FSMLocation(models.Model):
         compute="_compute_complete_name", recursive=True, store=True
     )
 
+    @api.model
+    def name_search(self, name="", args=None, operator="ilike", limit=100):
+        args = args or []
+        if name:
+            locations = self.search(
+                [
+                    "|",
+                    "|",
+                    ("name", operator, name),
+                    ("partner_id.vat", operator, name),
+                    ("email", operator, name),
+                ]
+                + args,
+                limit=limit,
+            )
+            return locations.name_get()
+        return super().name_search(name, args, operator, limit)
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:


### PR DESCRIPTION
This pr adds the name_search on fsm_locations to be able to search by locations name, partner vat and email.

cc https://github.com/APSL 9968

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review