### PR TITLE
[17.0][IMP] fieldservice: Added wizard to create sub-locations

### DIFF
--- a/fieldservice/README.rst
+++ b/fieldservice/README.rst
@@ -32,14 +32,14 @@ This module is the base of the Field Service application in Odoo.
 
 Videos from OCA Days:
 
-- 2024: `Field Service
-  Management <https://www.youtube.com/watch?v=zBCa3e9rLHU>`__
-- 2022: `Field Service - New features and
-  roadmap <https://www.youtube.com/watch?v=MH8agrNE88A>`__
-- 2021: `Job and Service Management for Install and
-  Construction <https://www.youtube.com/watch?v=b7iivgfzPoo>`__
-- 2020: `Advanced Field Service
-  Management <https://www.youtube.com/watch?v=7bq3cwMFeME>`__
+-  2024: `Field Service
+   Management <https://www.youtube.com/watch?v=zBCa3e9rLHU>`__
+-  2022: `Field Service - New features and
+   roadmap <https://www.youtube.com/watch?v=MH8agrNE88A>`__
+-  2021: `Job and Service Management for Install and
+   Construction <https://www.youtube.com/watch?v=b7iivgfzPoo>`__
+-  2020: `Advanced Field Service
+   Management <https://www.youtube.com/watch?v=7bq3cwMFeME>`__
 
 **Table of contents**
 
@@ -213,35 +213,35 @@ Authors
 Contributors
 ------------
 
-- Wolfgang Hall <whall@opensourceintegrators.com>
-- Maxime Chambreuil <mchambreuil@opensourceintegrators.com>
-- Steve Campbell <scampbell@opensourceintegrators.com>
-- Bhavesh Odedra <bodedra@opensourceintegrators.com>
-- Michael Allen <mallen@opensourceintegrators.com>
-- Sandip Mangukiya <smangukiya@opensourceintegrators.com>
-- Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
-- Brian McMaster <brian@mcmpest.com>
-- Raphaël Reverdy <raphael.reverdy@akretion.com>
-- Ammar Officewala <ammar.o.serpentcs@gmail.com>
-- Yves Goldberg <yves@ygol.com>
-- Freni Patel <fpatel@opensourceintegrators.com>
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  Wolfgang Hall <whall@opensourceintegrators.com>
+-  Maxime Chambreuil <mchambreuil@opensourceintegrators.com>
+-  Steve Campbell <scampbell@opensourceintegrators.com>
+-  Bhavesh Odedra <bodedra@opensourceintegrators.com>
+-  Michael Allen <mallen@opensourceintegrators.com>
+-  Sandip Mangukiya <smangukiya@opensourceintegrators.com>
+-  Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+-  Brian McMaster <brian@mcmpest.com>
+-  Raphaël Reverdy <raphael.reverdy@akretion.com>
+-  Ammar Officewala <ammar.o.serpentcs@gmail.com>
+-  Yves Goldberg <yves@ygol.com>
+-  Freni Patel <fpatel@opensourceintegrators.com>
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Víctor Martínez
+   -  Víctor Martínez
 
-- Nils Coenen <nils.coenen@nico-solutions.de>
-- Alex Comba <alex.comba@agilebg.com>
-- `APSL-Nagarro <https://apsl.tech>`__:
+-  Nils Coenen <nils.coenen@nico-solutions.de>
+-  Alex Comba <alex.comba@agilebg.com>
+-  `APSL-Nagarro <https://apsl.tech>`__:
 
-  - Bernat Obrador <bobrador@apsl.net>
-  - Antoni Marroig <amarroig@apsl.net>
+   -  Bernat Obrador <bobrador@apsl.net>
+   -  Antoni Marroig <amarroig@apsl.net>
 
 Other credits
 -------------
 
 The development of this module has been financially supported by:
 
-- Open Source Integrators <https://opensourceintegrators.com>
+-  Open Source Integrators <https://opensourceintegrators.com>
 
 Maintainers
 -----------

--- a/fieldservice/__manifest__.py
+++ b/fieldservice/__manifest__.py
@@ -35,6 +35,7 @@
         "views/fsm_team.xml",
         "views/menu.xml",
         "wizard/fsm_wizard.xml",
+        "wizard/fsm_create_sublocation_wizard.xml",
     ],
     "demo": [
         "demo/fsm_demo.xml",

--- a/fieldservice/security/ir.model.access.csv
+++ b/fieldservice/security/ir.model.access.csv
@@ -23,3 +23,5 @@ access_fsm_order_type_user,fsm.order.type.user,model_fsm_order_type,fieldservice
 access_fsm_order_type_manager,fsm.order.type.manager,model_fsm_order_type,fieldservice.group_fsm_manager,1,1,1,1
 access_fsm_calendar_filter,fsm.calendar.filter.user,model_fsm_person_calendar_filter,fieldservice.group_fsm_user_own,1,1,1,1
 access_fsm_wizard,access_fsm_wizard,model_fsm_wizard,fieldservice.group_fsm_dispatcher,1,1,1,0
+access_fsm_sublocation_wizard_dispacher,access_fsm_sublocation_wizard,model_fsm_create_sub_location_wizard,fieldservice.group_fsm_dispatcher,1,1,1,1
+access_fsm_sublocation_wizard_manager,access_fsm_sublocation_wizard,model_fsm_create_sub_location_wizard,fieldservice.group_fsm_manager,1,1,1,1

--- a/fieldservice/tests/__init__.py
+++ b/fieldservice/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_fsm_order
 from . import test_fsm_order_template_onchange
 from . import test_fsm_category
 from . import test_res_partner
+from . import test_fsm_wizard_create_sub_location

--- a/fieldservice/tests/test_fsm_wizard_create_sub_location.py
+++ b/fieldservice/tests/test_fsm_wizard_create_sub_location.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2025 - TODAY, APSL - Nagarro (Bernat Obrador)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import requests
+
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCreateSubLocationWizard(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._super_send = requests.Session.send
+        super().setUpClass()
+
+        location_vals = {
+            "name": "Main Location",
+            "owner_id": cls.env.ref("base.res_partner_1").id,
+        }
+        if cls.env["ir.module.module"].search(
+            [
+                ("name", "=", "fieldservice_account_analytic"),
+                ("state", "=", "installed"),
+            ]
+        ):
+            location_vals.update({"customer_id": cls.env.ref("base.res_partner_1").id})
+
+        cls.location = cls.env["fsm.location"].create(
+            location_vals,
+        )
+
+    @classmethod
+    def _request_handler(cls, s, r, /, **kw):
+        """Don't block external requests."""
+        return cls._super_send(s, r, **kw)
+
+    def test_create_sub_location(self):
+        (
+            self.env["fsm.create.sub.location.wizard"]
+            .sudo()
+            .create(
+                {
+                    "parent_location_id": self.location.id,
+                    "related_owner_id": self.env.ref("base.res_partner_1").id,
+                    "street": "Sub location street",
+                }
+            )
+        ).create_sub_location()
+
+        sub_location = self.env["fsm.location"].search(
+            [("fsm_parent_id", "=", self.location.id)]
+        )
+        self.assertTrue(sub_location)
+        self.assertTrue(len(sub_location) == 1)
+        self.assertEqual(
+            sub_location.name,
+            f"{self.location.name} - {sub_location.street}",
+        )

--- a/fieldservice/wizard/__init__.py
+++ b/fieldservice/wizard/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import fsm_wizard
+from . import fsm_create_sublocation_wizard

--- a/fieldservice/wizard/fsm_create_sublocation_wizard.py
+++ b/fieldservice/wizard/fsm_create_sublocation_wizard.py
@@ -1,0 +1,117 @@
+# Copyright (C) 2025 - TODAY, APSL - Nagarro (Bernat Obrador)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class CreateSubLocationWizard(models.TransientModel):
+    _name = "fsm.create.sub.location.wizard"
+    _inherit = ["format.address.mixin"]
+    _description = "Wizard to Create Sub Location"
+
+    name = fields.Char(compute="_compute_name", store=True)
+    parent_location_id = fields.Many2one(
+        "fsm.location", string="Parent Location", required=True
+    )
+    related_owner_id = fields.Many2one(
+        "res.partner", string="Related Owner", required=True
+    )
+    phone = fields.Char()
+    email = fields.Char()
+    street = fields.Char()
+    street2 = fields.Char()
+    zip = fields.Char(change_default=True)
+    city = fields.Char()
+    state_id = fields.Many2one(
+        "res.country.state",
+        string="State",
+        ondelete="restrict",
+        domain="[('country_id', '=?', country_id)]",
+    )
+    country_id = fields.Many2one("res.country", string="Country", ondelete="restrict")
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        if res.get("parent_location_id"):
+            parent_location = self.env["fsm.location"].browse(res["parent_location_id"])
+            res.update(
+                {
+                    "related_owner_id": parent_location.owner_id.id,
+                    "street": parent_location.street,
+                    "street2": parent_location.street2,
+                    "zip": parent_location.zip,
+                    "state_id": parent_location.state_id.id,
+                    "country_id": parent_location.country_id.id,
+                    "city": parent_location.city,
+                    "phone": parent_location.phone,
+                    "email": parent_location.email,
+                }
+            )
+        return res
+
+    @api.depends("parent_location_id", "street", "city")
+    def _compute_name(self):
+        for wizard in self:
+            parts = [wizard.parent_location_id.name]
+            if wizard.city != wizard.parent_location_id.city:
+                parts.append(wizard.city)
+            elif wizard.street != wizard.parent_location_id.street:
+                parts.append(wizard.street)
+            wizard.name = " - ".join(parts)
+
+    def _get_location_vals(self, partner_id):
+        # To avoid conflicts with fieldservice_account_analytic
+        vals = {
+            "name": self.name,
+            "partner_id": partner_id.id,
+            "fsm_parent_id": self.parent_location_id.id,
+            "owner_id": self.related_owner_id.id,
+            "street": self.street,
+            "street2": self.street2,
+            "zip": self.zip,
+            "city": self.city,
+            "state_id": self.state_id.id,
+            "country_id": self.country_id.id,
+        }
+
+        if (
+            self.env["ir.module.module"]
+            .sudo()
+            .search(
+                [
+                    ("name", "=", "fieldservice_account_analytic"),
+                    ("state", "=", "installed"),
+                ]
+            )
+        ):
+            vals["customer_id"] = (
+                self.parent_location_id.customer_id.id or self.related_owner_id.id
+            )
+
+        return vals
+
+    def create_sub_location(self):
+        partner_id = self.env["res.partner"].create(
+            {
+                "name": self.name,
+                "parent_id": self.parent_location_id.partner_id.id,
+                "street": self.street,
+                "street2": self.street2,
+                "zip": self.zip,
+                "city": self.city,
+                "state_id": self.state_id.id,
+                "country_id": self.country_id.id,
+                "phone": self.phone,
+                "email": self.email,
+            }
+        )
+        location = self.env["fsm.location"].create(self._get_location_vals(partner_id))
+
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "fsm.location",
+            "res_id": location.id,
+            "view_mode": "form",
+            "target": "current",
+        }

--- a/fieldservice/wizard/fsm_create_sublocation_wizard.xml
+++ b/fieldservice/wizard/fsm_create_sublocation_wizard.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_create_sub_location_wizard" model="ir.ui.view">
+        <field name="name">fsm.create.sub.location.wizard.form</field>
+        <field name="model">fsm.create.sub.location.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Create Sub Location">
+                <group>
+                    <field name="name" readonly="0" />
+                    <field name="parent_location_id" readonly="1" />
+                    <field name="related_owner_id" />
+
+                    <field name="email" widget="email" />
+                    <field name="phone" widget="phone" />
+                </group>
+                <group>
+                    <label for="street" string="Address" />
+                    <div class="o_address_format">
+                        <field
+                            name="street"
+                            placeholder="Street..."
+                            class="o_address_street"
+                        />
+                        <field
+                            name="street2"
+                            placeholder="Street 2..."
+                            class="o_address_street"
+                        />
+                        <field name="city" placeholder="City" class="o_address_city" />
+                        <field
+                            name="state_id"
+                            class="o_address_state"
+                            placeholder="State"
+                            options="{'no_open': True, 'no_quick_create': True}"
+                            context="{'default_country_id': country_id}"
+                        />
+                        <field name="zip" placeholder="ZIP" class="o_address_zip" />
+                        <field
+                            name="country_id"
+                            placeholder="Country"
+                            class="o_address_country"
+                            options="{'no_open': True, 'no_create': True}"
+                        />
+                    </div>
+                </group>
+                <footer>
+                    <button
+                        name="create_sub_location"
+                        type="object"
+                        string="Create"
+                        class="btn-primary"
+                    />
+                    <button string="Cancel" class="btn-secondary" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_create_sub_location" model="ir.actions.act_window">
+        <field name="name">Create Sub Location</field>
+        <field name="res_model">fsm.create.sub.location.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+    <record id="fsm_location_form_inherit" model="ir.ui.view">
+        <field name="name">fsm.location.form.inherit.sub.location</field>
+        <field name="model">fsm.location</field>
+        <field name="inherit_id" ref="fieldservice.fsm_location_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <button
+                    name="%(action_create_sub_location)d"
+                    string="Create Sub-Location"
+                    type="action"
+                    context="{'default_parent_location_id': active_id}"
+                    class="oe_highlight"
+                    groups="fieldservice.group_fsm_manager,fieldservice.group_fsm_dispatcher"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR adds a wizard to easily create sub-locations from locations.

This option is only allowed from fsm_dispatcher and fsm_manager, and they need `Extra Rigths: Contact Creation `

To test this, you just need to go to a location, use the button `Create Sub-location` and fill the wizard.

cc https://github.com/APSL 9970

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review