### PR TITLE
[15.0][IMP] fieldservice_sale_stock_route: update sale delivery dates from FSM order

### DIFF
--- a/fieldservice_sale_stock_route/README.rst
+++ b/fieldservice_sale_stock_route/README.rst
@@ -92,6 +92,7 @@ Contributors
 
  `APSL-Nagarro <https://www.apsl.tech>`_:
   * Patryk Pyczko <ppyczko@apsl.net>
+  * Bernat Obrador <bobrador@apsl.net>
 
 Maintainers
 ~~~~~~~~~~~

--- a/fieldservice_sale_stock_route/models/fsm_order.py
+++ b/fieldservice_sale_stock_route/models/fsm_order.py
@@ -13,6 +13,52 @@ class FSMOrder(models.Model):
         compute="_compute_postpone_button_visibility", store=False
     )
 
+    def write(self, vals):
+        res = super().write(vals)
+
+        if vals.get("scheduled_date_start") or vals.get("scheduled_date_end"):
+            for record in self:
+                if record.sale_id:
+                    sale = record.sale_id
+
+                    old_start = sale.commitment_date
+                    old_end = sale.commitment_date_end
+
+                    new_start = record.scheduled_date_start
+                    new_end = record.scheduled_date_end
+
+                    changes = []
+
+                    if old_start != new_start:
+                        sale.commitment_date = new_start
+                        changes.append(
+                            _("- Delivery Date: %(old)s → %(new)s")
+                            % {
+                                "old": old_start or "—",
+                                "new": new_start or "—",
+                            }
+                        )
+
+                    if old_end != new_end:
+                        sale.commitment_date_end = new_end
+                        changes.append(
+                            _("- Delivery End Date: %(old)s → %(new)s")
+                            % {
+                                "old": old_end or "—",
+                                "new": new_end or "—",
+                            }
+                        )
+
+                    if changes:
+                        body = _("<b>Updated Delivery Dates:</b><br/>") + "<br/>".join(
+                            changes
+                        )
+                        sale.message_post(
+                            body=body, subtype_id=self.env.ref("mail.mt_note").id
+                        )
+
+        return res
+
     def _is_valid_fsm_order(self, fsm_order):
         required_fields = [
             fsm_order.sale_id,

--- a/fieldservice_sale_stock_route/readme/CONTRIBUTORS.rst
+++ b/fieldservice_sale_stock_route/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
  `APSL-Nagarro <https://www.apsl.tech>`_:
   * Patryk Pyczko <ppyczko@apsl.net>
+  * Bernat Obrador <bobrador@apsl.net>

--- a/fieldservice_sale_stock_route/static/description/index.html
+++ b/fieldservice_sale_stock_route/static/description/index.html
@@ -440,6 +440,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <dt><a class="reference external" href="https://www.apsl.tech">APSL-Nagarro</a>:</dt>
 <dd><ul class="first last simple">
 <li>Patryk Pyczko &lt;<a class="reference external" href="mailto:ppyczko&#64;apsl.net">ppyczko&#64;apsl.net</a>&gt;</li>
+<li>Bernat Obrador &lt;<a class="reference external" href="mailto:bobrador&#64;apsl.net">bobrador&#64;apsl.net</a>&gt;</li>
 </ul>
 </dd>
 </dl>

--- a/fieldservice_sale_stock_route/tests/test_fieldservice_sale_stock_route.py
+++ b/fieldservice_sale_stock_route/tests/test_fieldservice_sale_stock_route.py
@@ -235,3 +235,36 @@ class TestFieldServiceSaleStockRoute(TransactionCase):
             self.fail(
                 "ValidationError was raised even though force_schedule is enabled."
             )
+
+    @freeze_time("2025-05-15")
+    def test_commitment_date_updated_on_fsm_write(self):
+        FSMOrder = self.env["fsm.order"]
+
+        fsm_order = FSMOrder.create(
+            {
+                "location_id": self.test_location.id,
+                "sale_id": self.sale_order.id,
+            }
+        )
+
+        new_start = datetime.now()
+        new_end = new_start + timedelta(hours=1)
+
+        fsm_order.write(
+            {
+                "scheduled_date_start": new_start,
+                "scheduled_date_end": new_end,
+            }
+        )
+
+        self.sale_order.invalidate_cache()
+        self.assertEqual(self.sale_order.commitment_date, new_start)
+        self.assertEqual(self.sale_order.commitment_date_end, new_end)
+
+        messages = self.sale_order.message_ids.filtered(
+            lambda m: "Updated Delivery Dates" in m.body
+        )
+        self.assertTrue(messages)
+        message = messages[0]
+        self.assertIn("- Delivery Date:", message.body)
+        self.assertIn("- Delivery End Date:", message.body)


### PR DESCRIPTION
Ensure that when `scheduled_date_start` or `scheduled_date_end` are changed on an FSM order,
the corresponding `commitment_date` and `commitment_date_end` fields on the related sale order
are automatically updated on save.


cc https://github.com/APSL HT02030

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review

