### PR TITLE
[15.0][FIX] fieldservice_sale_stock_route: Start route day calculation from tomorrow

### DIFF
--- a/fieldservice_sale_stock_route/models/sale_order.py
+++ b/fieldservice_sale_stock_route/models/sale_order.py
@@ -107,9 +107,11 @@ class SaleOrder(models.Model):
                 # Get allowed FSM days (1=Monday, 7=Sunday)
                 allowed_days = fsm_route.day_ids.mapped("id")
 
-                order.commitment_date = (
-                    order.commitment_date or order._get_next_route_day()
-                )
+                if not order.commitment_date:
+                    tomorrow = fields.Datetime.now() + timedelta(days=1)
+                    order.commitment_date = order._get_next_route_day(
+                        from_date=tomorrow
+                    )
 
                 # Convert weekday() days (0-6) to FSM days (1-7)
                 scheduled_day = order.commitment_date.weekday() + 1

--- a/fieldservice_sale_stock_route/tests/test_fieldservice_sale_stock_route.py
+++ b/fieldservice_sale_stock_route/tests/test_fieldservice_sale_stock_route.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 
 from freezegun import freeze_time
 
+from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
@@ -52,7 +53,8 @@ class TestFieldServiceSaleStockRoute(TransactionCase):
         Test that commitment_date and commitment_date_end are correctly
         computed when the sale order is confirmed.
         """
-        next_route_day = self.sale_order._get_next_route_day()
+        tomorrow = fields.Datetime.now() + timedelta(days=1)
+        next_route_day = self.sale_order._get_next_route_day(from_date=tomorrow)
         self.sale_order._action_confirm()
 
         self.assertTrue(


### PR DESCRIPTION
If a sale order was confirmed late at night, the system could schedule the delivery for the same day, even if the day was almost over. This PR ensures that the next available route day is calculated starting from tomorrow, avoiding same-day scheduling during late confirmations.