### PR TITLE
[15.0][IMP] fieldservice_website_sale: add setting to set default time range on e-commerce orders

### DIFF
--- a/fieldservice_website_sale/README.rst
+++ b/fieldservice_website_sale/README.rst
@@ -62,6 +62,7 @@ Usage
 - Under `Configuration` > `Availability` > `Delivery Time Ranges`, create delivery time ranges.
 - When the `Route` field is specified, the delivery time range is used on the related route only. When the `Route` field is empty, the delivery time range is used on all routes.
 - Save the delivery time ranges.
+- You can also set a default delivery time range in the `Field Service` module under `Configuration` > `Settings` > `Website Sales` > `Auto-assign Default Delivery Time Range`. This will be used when a delivery date is selected during the checkout process, but no specific delivery time range is selected.
 
 5. **Configure Maximum Allowed Time for Order Placement**
 - Navigate to the `Field Service` module.

--- a/fieldservice_website_sale/controllers/main.py
+++ b/fieldservice_website_sale/controllers/main.py
@@ -135,8 +135,26 @@ class PaymentPortal(website_sale_controller.PaymentPortal):
         selected_date = kwargs.get("selected_date")
         selected_time_range = kwargs.get("selected_time_range")
 
-        if not selected_date or not selected_time_range:
-            raise ValidationError(_("Please select a delivery date and time range."))
+        config = request.env["res.config.settings"].sudo().get_values()
+        auto_assign = config.get("auto_assign_default_time_range", False)
+
+        if not selected_date:
+            raise ValidationError(_("Please select a delivery date."))
+
+        if not selected_time_range and auto_assign:
+            time_range_default_id = config.get("time_range_default_id")
+            if time_range_default_id:
+                time_range = (
+                    request.env["fsm.delivery.time.range"]
+                    .sudo()
+                    .browse(time_range_default_id)
+                )
+                if time_range.exists():
+                    selected_time_range = time_range.id
+                    kwargs["selected_time_range"] = selected_time_range
+
+        if not selected_time_range:
+            raise ValidationError(_("Please select a delivery time range."))
 
         order = (
             request.env["sale.order"].sudo().search([("id", "=", kwargs["order_id"])])

--- a/fieldservice_website_sale/i18n/ca.po
+++ b/fieldservice_website_sale/i18n/ca.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-12 13:05+0000\n"
-"PO-Revision-Date: 2025-03-12 13:05+0000\n"
+"POT-Creation-Date: 2025-06-03 14:35+0000\n"
+"PO-Revision-Date: 2025-06-03 14:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,17 +18,28 @@ msgstr ""
 #. module: fieldservice_website_sale
 #: model:ir.model.fields.selection,name:fieldservice_website_sale.selection__res_config_settings__max_date_number__10
 msgid "10"
-msgstr ""
+msgstr "10"
 
 #. module: fieldservice_website_sale
 #: model:ir.model.fields.selection,name:fieldservice_website_sale.selection__res_config_settings__max_date_number__11
 msgid "11"
-msgstr ""
+msgstr "11"
 
 #. module: fieldservice_website_sale
 #: model:ir.model.fields.selection,name:fieldservice_website_sale.selection__res_config_settings__max_date_number__12
 msgid "12"
+msgstr "12"
+
+#. module: fieldservice_website_sale
+#: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
+msgid ""
+"<span class=\"o_form_label\">\n"
+"                Auto-assign Default Delivery Time Range\n"
+"              </span>"
 msgstr ""
+"<span class=\"o_form_label\">\n"
+"                Assigna automàticament l'interval horari de lliurament per defecte\n"
+"              </span>"
 
 #. module: fieldservice_website_sale
 #: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
@@ -57,6 +68,12 @@ msgid "<span class=\"text-muted\">Unavailable Day</span>"
 msgstr "<span class=\"text-muted\">Dia no disponible</span>"
 
 #. module: fieldservice_website_sale
+#: model:ir.model.fields,field_description:fieldservice_website_sale.field_res_config_settings__auto_assign_default_time_range
+#: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
+msgid "Auto-assign default delivery time range"
+msgstr "Assigna automàticament l'interval horari de lliurament per defecte"
+
+#. module: fieldservice_website_sale
 #: model:ir.model,name:fieldservice_website_sale.model_res_config_settings
 msgid "Config Settings"
 msgstr "Ajustos de configuració"
@@ -65,6 +82,31 @@ msgstr "Ajustos de configuració"
 #: model:ir.model.fields.selection,name:fieldservice_website_sale.selection__res_config_settings__max_date_unit__days
 msgid "Days"
 msgstr "Dies"
+
+#. module: fieldservice_website_sale
+#: model:ir.model.fields,field_description:fieldservice_website_sale.field_res_config_settings__time_range_default_id
+#: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
+msgid "Default Delivery Time Range"
+msgstr "Interval horari de lliurament per defecte"
+
+#. module: fieldservice_website_sale
+#: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
+msgid ""
+"Enable this option to automatically assign a default delivery time range to new\n"
+"                orders. This helps streamline order scheduling by preselecting a time range for\n"
+"                customers."
+msgstr ""
+"Activeu aquesta opció per assignar automàticament un interval horari de lliurament per defecte a les noves\n"
+"                comandes. Això ajuda a agilitzar la programació de comandes preseleccionant un interval horari per als\n"
+"                clients."
+
+#. module: fieldservice_website_sale
+#: model:ir.model.fields,help:fieldservice_website_sale.field_res_config_settings__auto_assign_default_time_range
+msgid ""
+"If enabled, a default delivery time range will be auto-assigned when not "
+"selected by the user."
+msgstr ""
+"Si està activat, s'assignarà automàticament un interval horari de lliurament per defecte quan l'usuari no en seleccioni cap."
 
 #. module: fieldservice_website_sale
 #: model:ir.model.fields,field_description:fieldservice_website_sale.field_res_config_settings__max_date_number
@@ -87,7 +129,9 @@ msgid ""
 "No delivery dates are available because a valid delivery route hasn't been "
 "assigned to the selected address. Please reach out to us using this"
 msgstr ""
-"No hi ha dates de lliurament disponibles perquè no s'ha assignat una ruta de lliurament vàlida a l'adreça seleccionada. Poseu-vos en contacte amb nosaltres utilitzant aquest"
+"No hi ha dates de lliurament disponibles perquè no s'ha assignat una ruta de"
+" lliurament vàlida a l'adreça seleccionada. Poseu-vos en contacte amb "
+"nosaltres utilitzant aquest"
 
 #. module: fieldservice_website_sale
 #: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
@@ -97,9 +141,14 @@ msgstr "Número"
 #. module: fieldservice_website_sale
 #: code:addons/fieldservice_website_sale/controllers/main.py:0
 #, python-format
-msgid "Please select a delivery date and time range."
-msgstr ""
-"Si us plau, seleccioneu una data i un interval de temps de lliurament."
+msgid "Please select a delivery date."
+msgstr "Si us plau, seleccioneu una data de lliurament."
+
+#. module: fieldservice_website_sale
+#: code:addons/fieldservice_website_sale/controllers/main.py:0
+#, python-format
+msgid "Please select a delivery time range."
+msgstr "Si us plau, seleccioneu un interval horari de lliurament."
 
 #. module: fieldservice_website_sale
 #: model:ir.model,name:fieldservice_website_sale.model_sale_order
@@ -121,6 +170,14 @@ msgstr ""
 "Especifiqueu el termini màxim per a la realització de comandes futures seleccionant un número i una\n"
 "                unitat (per exemple, '1 mes', '2 setmanes'). Això determina fins a quin punt en el futur els clients\n"
 "                poden programar les seves comandes."
+
+#. module: fieldservice_website_sale
+#: model:ir.model.fields,help:fieldservice_website_sale.field_res_config_settings__time_range_default_id
+msgid ""
+"Time range to auto-assign when 'Auto-assign default delivery time range' is "
+"enabled."
+msgstr ""
+"Interval horari que s'assignarà automàticament quan l'opció 'Assigna automàticament l'interval horari de lliurament per defecte' estigui activada."
 
 #. module: fieldservice_website_sale
 #: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form

--- a/fieldservice_website_sale/i18n/es.po
+++ b/fieldservice_website_sale/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-12 13:04+0000\n"
-"PO-Revision-Date: 2025-03-12 13:04+0000\n"
+"POT-Creation-Date: 2025-06-03 14:35+0000\n"
+"PO-Revision-Date: 2025-06-03 14:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,17 +18,28 @@ msgstr ""
 #. module: fieldservice_website_sale
 #: model:ir.model.fields.selection,name:fieldservice_website_sale.selection__res_config_settings__max_date_number__10
 msgid "10"
-msgstr ""
+msgstr "10"
 
 #. module: fieldservice_website_sale
 #: model:ir.model.fields.selection,name:fieldservice_website_sale.selection__res_config_settings__max_date_number__11
 msgid "11"
-msgstr ""
+msgstr "11"
 
 #. module: fieldservice_website_sale
 #: model:ir.model.fields.selection,name:fieldservice_website_sale.selection__res_config_settings__max_date_number__12
 msgid "12"
+msgstr "12"
+
+#. module: fieldservice_website_sale
+#: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
+msgid ""
+"<span class=\"o_form_label\">\n"
+"                Auto-assign Default Delivery Time Range\n"
+"              </span>"
 msgstr ""
+"<span class=\"o_form_label\">\n"
+"                Asignar automáticamente el rango de tiempo de entrega predeterminado\n"
+"              </span>"
 
 #. module: fieldservice_website_sale
 #: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
@@ -57,6 +68,12 @@ msgid "<span class=\"text-muted\">Unavailable Day</span>"
 msgstr "<span class=\"text-muted\">Día No Disponible</span>"
 
 #. module: fieldservice_website_sale
+#: model:ir.model.fields,field_description:fieldservice_website_sale.field_res_config_settings__auto_assign_default_time_range
+#: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
+msgid "Auto-assign default delivery time range"
+msgstr "Asignar automáticamente el rango de tiempo de entrega predeterminado"
+
+#. module: fieldservice_website_sale
 #: model:ir.model,name:fieldservice_website_sale.model_res_config_settings
 msgid "Config Settings"
 msgstr "Opciones de configuración"
@@ -65,6 +82,32 @@ msgstr "Opciones de configuración"
 #: model:ir.model.fields.selection,name:fieldservice_website_sale.selection__res_config_settings__max_date_unit__days
 msgid "Days"
 msgstr "Días"
+
+#. module: fieldservice_website_sale
+#: model:ir.model.fields,field_description:fieldservice_website_sale.field_res_config_settings__time_range_default_id
+#: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
+msgid "Default Delivery Time Range"
+msgstr "Rango de Tiempo de Entrega Predeterminado"
+
+#. module: fieldservice_website_sale
+#: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
+msgid ""
+"Enable this option to automatically assign a default delivery time range to new\n"
+"                orders. This helps streamline order scheduling by preselecting a time range for\n"
+"                customers."
+msgstr ""
+"Habilite esta opción para asignar automáticamente un rango de tiempo de entrega predeterminado a los nuevos\n"
+"                pedidos. Esto ayuda a agilizar la programación de pedidos preseleccionando un rango de tiempo para\n"
+"                los clientes."
+
+#. module: fieldservice_website_sale
+#: model:ir.model.fields,help:fieldservice_website_sale.field_res_config_settings__auto_assign_default_time_range
+msgid ""
+"If enabled, a default delivery time range will be auto-assigned when not "
+"selected by the user."
+msgstr ""
+"Si está habilitado, se asignará automáticamente un rango de tiempo de entrega predeterminado cuando no "
+"sea seleccionado por el usuario."
 
 #. module: fieldservice_website_sale
 #: model:ir.model.fields,field_description:fieldservice_website_sale.field_res_config_settings__max_date_number
@@ -87,7 +130,9 @@ msgid ""
 "No delivery dates are available because a valid delivery route hasn't been "
 "assigned to the selected address. Please reach out to us using this"
 msgstr ""
-"No hay fechas de entrega disponibles porque no se ha asignado una ruta de entrega válida a la dirección seleccionada. Por favor, contáctenos usando este"
+"No hay fechas de entrega disponibles porque no se ha asignado una ruta de "
+"entrega válida a la dirección seleccionada. Por favor, contáctenos usando "
+"este"
 
 #. module: fieldservice_website_sale
 #: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
@@ -97,8 +142,14 @@ msgstr "Número"
 #. module: fieldservice_website_sale
 #: code:addons/fieldservice_website_sale/controllers/main.py:0
 #, python-format
-msgid "Please select a delivery date and time range."
-msgstr "Por favor, seleccione una fecha y un rango de tiempo de entrega."
+msgid "Please select a delivery date."
+msgstr "Por favor, seleccione una fecha de entrega."
+
+#. module: fieldservice_website_sale
+#: code:addons/fieldservice_website_sale/controllers/main.py:0
+#, python-format
+msgid "Please select a delivery time range."
+msgstr "Por favor, seleccione un rango de tiempo de entrega."
 
 #. module: fieldservice_website_sale
 #: model:ir.model,name:fieldservice_website_sale.model_sale_order
@@ -120,6 +171,14 @@ msgstr ""
 "Especifique el marco de tiempo máximo para la realización de pedidos futuros seleccionando un número y una\n"
 "                unidad (por ejemplo, '1 mes', '2 semanas'). Esto determina cuán lejos en el futuro los clientes\n"
 "                pueden programar sus pedidos."
+
+#. module: fieldservice_website_sale
+#: model:ir.model.fields,help:fieldservice_website_sale.field_res_config_settings__time_range_default_id
+msgid ""
+"Time range to auto-assign when 'Auto-assign default delivery time range' is "
+"enabled."
+msgstr ""
+"Rango de tiempo que se asignará automáticamente cuando la opción 'Asignar automáticamente el rango de tiempo de entrega predeterminado' esté habilitada."
 
 #. module: fieldservice_website_sale
 #: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form

--- a/fieldservice_website_sale/i18n/fieldservice_website_sale.pot
+++ b/fieldservice_website_sale/i18n/fieldservice_website_sale.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-03 14:35+0000\n"
+"PO-Revision-Date: 2025-06-03 14:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -32,6 +34,14 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
 msgid ""
 "<span class=\"o_form_label\">\n"
+"                Auto-assign Default Delivery Time Range\n"
+"              </span>"
+msgstr ""
+
+#. module: fieldservice_website_sale
+#: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
+msgid ""
+"<span class=\"o_form_label\">\n"
 "                Maximum Allowed Time for Order Placement\n"
 "              </span>"
 msgstr ""
@@ -52,6 +62,12 @@ msgid "<span class=\"text-muted\">Unavailable Day</span>"
 msgstr ""
 
 #. module: fieldservice_website_sale
+#: model:ir.model.fields,field_description:fieldservice_website_sale.field_res_config_settings__auto_assign_default_time_range
+#: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
+msgid "Auto-assign default delivery time range"
+msgstr ""
+
+#. module: fieldservice_website_sale
 #: model:ir.model,name:fieldservice_website_sale.model_res_config_settings
 msgid "Config Settings"
 msgstr ""
@@ -59,6 +75,27 @@ msgstr ""
 #. module: fieldservice_website_sale
 #: model:ir.model.fields.selection,name:fieldservice_website_sale.selection__res_config_settings__max_date_unit__days
 msgid "Days"
+msgstr ""
+
+#. module: fieldservice_website_sale
+#: model:ir.model.fields,field_description:fieldservice_website_sale.field_res_config_settings__time_range_default_id
+#: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
+msgid "Default Delivery Time Range"
+msgstr ""
+
+#. module: fieldservice_website_sale
+#: model_terms:ir.ui.view,arch_db:fieldservice_website_sale.res_config_settings_view_form
+msgid ""
+"Enable this option to automatically assign a default delivery time range to new\n"
+"                orders. This helps streamline order scheduling by preselecting a time range for\n"
+"                customers."
+msgstr ""
+
+#. module: fieldservice_website_sale
+#: model:ir.model.fields,help:fieldservice_website_sale.field_res_config_settings__auto_assign_default_time_range
+msgid ""
+"If enabled, a default delivery time range will be auto-assigned when not "
+"selected by the user."
 msgstr ""
 
 #. module: fieldservice_website_sale
@@ -91,7 +128,13 @@ msgstr ""
 #. module: fieldservice_website_sale
 #: code:addons/fieldservice_website_sale/controllers/main.py:0
 #, python-format
-msgid "Please select a delivery date and time range."
+msgid "Please select a delivery date."
+msgstr ""
+
+#. module: fieldservice_website_sale
+#: code:addons/fieldservice_website_sale/controllers/main.py:0
+#, python-format
+msgid "Please select a delivery time range."
 msgstr ""
 
 #. module: fieldservice_website_sale
@@ -110,6 +153,13 @@ msgid ""
 "Specify the maximum timeframe for future order placement by selecting a number and a\n"
 "                unit (e.g., '1 month', '2 weeks'). This determines how far into the future customers\n"
 "                can schedule their orders."
+msgstr ""
+
+#. module: fieldservice_website_sale
+#: model:ir.model.fields,help:fieldservice_website_sale.field_res_config_settings__time_range_default_id
+msgid ""
+"Time range to auto-assign when 'Auto-assign default delivery time range' is "
+"enabled."
 msgstr ""
 
 #. module: fieldservice_website_sale

--- a/fieldservice_website_sale/models/res_config_settings.py
+++ b/fieldservice_website_sale/models/res_config_settings.py
@@ -19,25 +19,57 @@ class ResConfigSettings(models.TransientModel):
         required=True,
     )
 
+    time_range_default_id = fields.Many2one(
+        "fsm.delivery.time.range",
+        string="Default Delivery Time Range",
+        help="Time range to auto-assign when 'Auto-assign "
+        "default delivery time range' is enabled.",
+    )
+
+    auto_assign_default_time_range = fields.Boolean(
+        string="Auto-assign default delivery time range",
+        default=False,
+        help="If enabled, a default delivery time range will be "
+        "auto-assigned when not selected by the user.",
+    )
+
     @api.model
     def set_values(self):
         super().set_values()
-
         self.env["ir.config_parameter"].set_param(
             "fieldservice.max_date_number", self.max_date_number
         )
         self.env["ir.config_parameter"].set_param(
             "fieldservice.max_date_unit", self.max_date_unit
         )
+        self.env["ir.config_parameter"].set_param(
+            "fieldservice.auto_assign_default_time_range",
+            self.auto_assign_default_time_range,
+        )
+        self.env["ir.config_parameter"].set_param(
+            "fieldservice.time_range_default_id",
+            self.time_range_default_id.id if self.time_range_default_id.id else False,
+        )
         return True
 
     @api.model
     def get_values(self):
         res = super().get_values()
-
         params = self.env["ir.config_parameter"].sudo()
+        time_range_default_id = params.get_param(
+            "fieldservice.time_range_default_id", False
+        )
         res.update(
             max_date_number=params.get_param("fieldservice.max_date_number", "1"),
             max_date_unit=params.get_param("fieldservice.max_date_unit", "months"),
+            auto_assign_default_time_range=params.get_param(
+                "fieldservice.auto_assign_default_time_range", "False"
+            )
+            == "True",
+            time_range_default_id=(
+                int(time_range_default_id)
+                if time_range_default_id and time_range_default_id.isdigit()
+                else False
+            ),
         )
         return res

--- a/fieldservice_website_sale/readme/USAGE.rst
+++ b/fieldservice_website_sale/readme/USAGE.rst
@@ -22,6 +22,7 @@
 - Under `Configuration` > `Availability` > `Delivery Time Ranges`, create delivery time ranges.
 - When the `Route` field is specified, the delivery time range is used on the related route only. When the `Route` field is empty, the delivery time range is used on all routes.
 - Save the delivery time ranges.
+- You can also set a default delivery time range in the `Field Service` module under `Configuration` > `Settings` > `Website Sales` > `Auto-assign Default Delivery Time Range`. This will be used when a delivery date is selected during the checkout process, but no specific delivery time range is selected.
 
 5. **Configure Maximum Allowed Time for Order Placement**
 - Navigate to the `Field Service` module.

--- a/fieldservice_website_sale/static/description/index.html
+++ b/fieldservice_website_sale/static/description/index.html
@@ -406,7 +406,8 @@ ul.auto-toc {
 - Navigate to the <cite>Field Service</cite> module.
 - Under <cite>Configuration</cite> &gt; <cite>Availability</cite> &gt; <cite>Delivery Time Ranges</cite>, create delivery time ranges.
 - When the <cite>Route</cite> field is specified, the delivery time range is used on the related route only. When the <cite>Route</cite> field is empty, the delivery time range is used on all routes.
-- Save the delivery time ranges.</p>
+- Save the delivery time ranges.
+- You can also set a default delivery time range in the <cite>Field Service</cite> module under <cite>Configuration</cite> &gt; <cite>Settings</cite> &gt; <cite>Website Sales</cite> &gt; <cite>Auto-assign Default Delivery Time Range</cite>. This will be used when a delivery date is selected during the checkout process, but no specific delivery time range is selected.</p>
 <p>5. <strong>Configure Maximum Allowed Time for Order Placement</strong>
 - Navigate to the <cite>Field Service</cite> module.
 - Under <cite>Configuration</cite> &gt; <cite>Settings</cite> &gt; <cite>Website Sales</cite>, configure the maximum allowed time for order placement.

--- a/fieldservice_website_sale/views/res_config_settings_views.xml
+++ b/fieldservice_website_sale/views/res_config_settings_views.xml
@@ -56,6 +56,54 @@
             </div>
           </div>
         </div>
+        <div class="row mt16 o_settings_container" id="orders">
+          <div class="col-xs-12 col-md-6 o_setting_box">
+            <div class="o_setting_left_pane" />
+            <div class="o_setting_right_pane">
+              <span class="o_form_label">
+                Auto-assign Default Delivery Time Range
+              </span>
+              <div class="text-muted">
+                Enable this option to automatically assign a default delivery time range to new
+                orders. This helps streamline order scheduling by preselecting a time range for
+                customers.
+              </div>
+              <div class="content-group">
+                <div class="row mt16">
+                  <label
+                                        string="Auto-assign default delivery time range"
+                                        for="auto_assign_default_time_range"
+                                        class="col-lg-3 o_light_label"
+                                    />
+                  <div class="col-lg-6">
+                    <field
+                                            name="auto_assign_default_time_range"
+                                            class="o_field_widget"
+                                        />
+                  </div>
+                </div>
+                <div
+                                    class="row mt16"
+                                    attrs="{'invisible': [('auto_assign_default_time_range', '=', False)]}"
+                                >
+                  <label
+                                        string="Default Delivery Time Range"
+                                        for="time_range_default_id"
+                                        class="col-lg-3 o_light_label"
+                                    />
+                  <div class="col-lg-6">
+                    <field
+                                            name="time_range_default_id"
+                                            class="o_field_widget"
+                                            options="{'no_create': True}"
+                                            attrs="{'required':[('auto_assign_default_time_range','!=',False)]}"
+                                        />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </xpath>
     </field>
   </record>


### PR DESCRIPTION
This PR adds a setting to set a default time range when completing a sale order from e-commerce without setting a time range manually.

cc https://github.com/APSL 9966

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador please review