### PR TITLE
[17.0][IMP] fieldservice_stock_scrap: Use intermediate location when scrap stock

### DIFF
--- a/fieldservice_stock_scrap/README.rst
+++ b/fieldservice_stock_scrap/README.rst
@@ -74,9 +74,9 @@ Authors
 Contributors
 ------------
 
-- [APSL-Nagarro](https://apsl.tech):
+-  `APSL-Nagarro <https://apsl.tech>`__:
 
-  - Antoni Marroig <amarroig@apsl.net>
+   -  Antoni Marroig <amarroig@apsl.net>
 
 Maintainers
 -----------

--- a/fieldservice_stock_scrap/__manifest__.py
+++ b/fieldservice_stock_scrap/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Field Service Stock Scrap",
     "summary": "Scrap stock from Field Service order of Stock Requests",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "category": "Field Service",
     "website": "https://github.com/OCA/field-service",
     "author": "Antoni Marroig, APSL-Nagarro, Odoo Community Association (OCA)",
@@ -19,5 +19,6 @@
         "views/stock_scrap.xml",
         "security/ir.model.access.csv",
         "wizards/scrap_stock_wizard.xml",
+        "data/stock_location.xml",
     ],
 }

--- a/fieldservice_stock_scrap/data/stock_location.xml
+++ b/fieldservice_stock_scrap/data/stock_location.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- # Copyright 2025 Antoni Marroig(APSL-Nagarro)<amarroig@apsl.net>
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+    <record id="intermediate_location" model="stock.location">
+        <field name="name">Intermediate Location</field>
+        <field name="usage">internal</field>
+        <field name="company_id" />
+    </record>
+</odoo>

--- a/fieldservice_stock_scrap/readme/CONTRIBUTORS.md
+++ b/fieldservice_stock_scrap/readme/CONTRIBUTORS.md
@@ -1,2 +1,2 @@
-- \[APSL-Nagarro\](<https://apsl.tech>):
+- [APSL-Nagarro](https://apsl.tech):
   - Antoni Marroig \<<amarroig@apsl.net>\>

--- a/fieldservice_stock_scrap/static/description/index.html
+++ b/fieldservice_stock_scrap/static/description/index.html
@@ -419,7 +419,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="contributors">
 <h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
 <ul class="simple">
-<li>[APSL-Nagarro](<a class="reference external" href="https://apsl.tech">https://apsl.tech</a>):<ul>
+<li><a class="reference external" href="https://apsl.tech">APSL-Nagarro</a>:<ul>
 <li>Antoni Marroig &lt;<a class="reference external" href="mailto:amarroig&#64;apsl.net">amarroig&#64;apsl.net</a>&gt;</li>
 </ul>
 </li>

--- a/fieldservice_stock_scrap/wizards/scrap_stock_wizard.py
+++ b/fieldservice_stock_scrap/wizards/scrap_stock_wizard.py
@@ -108,12 +108,14 @@ class ScrapStockWizard(models.TransientModel):
         for scrap in self:
             scrap.scrap_location_id = locations_per_company[scrap.company_id.id]
 
-    def scrap(self, location_id, product_id, scrap_qty, scrap_id):
+    def scrap(self, product_id, scrap_qty, scrap_id):
         move_id = self.env["stock.move"].create(
             {
                 "fsm_order_id": self.env.context["fsm_order_id"],
                 "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": location_id.id,
+                "location_dest_id": self.env.ref(
+                    "fieldservice_stock_scrap.intermediate_location"
+                ).id,
                 "product_id": product_id.id,
                 "picked": True,
                 "product_uom_qty": scrap_qty,
@@ -134,7 +136,9 @@ class ScrapStockWizard(models.TransientModel):
         move_id._action_done()
         scrap_id = self.env["stock.scrap"].create(
             {
-                "location_id": location_id.id,
+                "location_id": self.env.ref(
+                    "fieldservice_stock_scrap.intermediate_location"
+                ).id,
                 "scrap_location_id": self.scrap_location_id.id,
                 "product_id": product_id.id,
                 "scrap_qty": scrap_qty,
@@ -146,7 +150,7 @@ class ScrapStockWizard(models.TransientModel):
 
     def action_scrap(self):
         for line in self.scrap_stock_entries.filtered(lambda x: x.scrap_qty > 0):
-            self.scrap(line.location_id, line.product_id, line.scrap_qty, line.id)
+            self.scrap(line.product_id, line.scrap_qty, line.id)
             if line.stock_request_id.product_uom_qty - line.scrap_qty == 0:
                 line.stock_request_id.unlink()
             else:
@@ -161,7 +165,6 @@ class ScrapStockWizard(models.TransientModel):
 
         for request in unmatched_requests:
             self.scrap(
-                request.location_id,
                 request.product_id,
                 request.product_uom_qty,
                 request.id,


### PR DESCRIPTION
This improvement introduces an intermediate location for transferring stock between the customer location and the scrap location.

cc https://github.com/APSL
@miquelalzanillas @javierobcn @mpascuall @BernatObrador @ppyczko @lbarry-apsl please review