### PR TITLE
[16.0][FIX][fieldservice_reccuring]: Fix error in search view

### DIFF
--- a/fieldservice_recurring/views/fsm_recurring.xml
+++ b/fieldservice_recurring/views/fsm_recurring.xml
@@ -114,11 +114,7 @@
         <field name="model">fsm.recurring</field>
         <field name="arch" type="xml">
             <search string="Recurring Orders">
-                <field
-                    name="name"
-                    filter_domain="['|', ('name', 'ilike', self), ('name', '=like', str(self) + '%')]"
-                    string="FSM Recurring Order Name"
-                />
+                <field name="name" string="FSM Recurring Order Name" />
                 <field name="person_id" />
                 <field name="location_id" />
                 <field name="team_id" groups="fieldservice.group_fsm_team" />


### PR DESCRIPTION
Fixed error seen in search view under Operations > Recurring Orders for field name
"FSM Recurring Order Name".

Error shown as below:

![image](https://github.com/user-attachments/assets/43f417ce-5005-44f3-ba93-9b13ec1ec4ae)
