### PR TITLE
[17.0][IMP] fieldservice: Add timezone-aware date filters for FSM orders

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -3,6 +3,8 @@
 
 from datetime import datetime, timedelta
 
+import pytz
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import format_date
@@ -237,6 +239,22 @@ class FSMOrder(models.Model):
     type = fields.Many2one("fsm.order.type")
 
     internal_type = fields.Selection(related="type.internal_type")
+
+    date_today_order_tz = fields.Date(
+        string="Scheduled Date (User TZ)",
+        compute="_compute_date_today_order_tz",
+        store=True,
+    )
+
+    @api.depends("scheduled_date_start")
+    def _compute_date_today_order_tz(self):
+        tz = pytz.timezone(self.env.user.tz or "UTC")
+        for rec in self:
+            if rec.scheduled_date_start:
+                dt_user = rec.scheduled_date_start.astimezone(tz)
+                rec.date_today_order_tz = dt_user.date()
+            else:
+                rec.date_today_order_tz = False
 
     @api.model
     def _read_group_stage_ids(self, stages, domain, order):

--- a/fieldservice/tests/test_fsm_order.py
+++ b/fieldservice/tests/test_fsm_order.py
@@ -289,3 +289,23 @@ class TestFSMOrder(TestFSMOrderBase):
             order.stage_id.stage_type = "location"
             order.can_unlink()
             order.unlink()
+
+    @freeze_time("2025-06-19 22:30:00")  # UTC
+    def test_date_today_order_tz_timezone_dependent(self):
+        self.env.user.tz = "Europe/Madrid"
+
+        dt_utc = fields.Datetime.from_string("2025-06-19 22:30:00")
+
+        order = self.Order.create(
+            {
+                "scheduled_date_start": dt_utc,
+                "location_id": self.test_location.id,
+                "stage_id": self.stage1.id,
+            }
+        )
+
+        self.assertEqual(
+            order.date_today_order_tz,
+            fields.Date.from_string("2025-06-20"),
+            "date_today_order_tz should reflect 2025-06-20 for Europe/Madrid",
+        )

--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -378,38 +378,39 @@
                 <separator />
                 <filter
                     string="Today Orders"
-                    domain="[
-                    ('scheduled_date_start', '&gt;=', (datetime.datetime.combine(datetime.date.today(), datetime.time(0,0,0)))),
-                    ('scheduled_date_start', '&lt;', (datetime.datetime.combine(datetime.date.today(), datetime.time(23,59,59))))
-                    ]"
                     name="order_today"
+                    domain="[('date_today_order_tz', '=', context_today())]"
                 />
+
                 <filter
                     string="Future Orders"
-                    domain="[('scheduled_date_start', '&gt;=', (datetime.datetime.combine(datetime.date.today(), datetime.time(0,0,0))))]"
                     name="order_upcoming_all"
+                    domain="[('date_today_order_tz', '&gt;', context_today())]"
                 />
+
                 <filter
                     string="Due Within 7 Days"
-                    domain="[
-                    ('scheduled_date_start', '&gt;=', (datetime.datetime.combine(datetime.date.today(), datetime.time(0,0,0)))),
-                    ('scheduled_date_start', '&lt;=', (datetime.datetime.combine((datetime.date.today()+relativedelta(days=6)), datetime.time(23,59,59))))
-                    ]"
                     name="order_upcoming_week"
+                    domain="[
+                            ('date_today_order_tz', '&gt;=', context_today()),
+                            ('date_today_order_tz', '&lt;=', (context_today() + relativedelta(days=6)))
+                        ]"
                 />
+
                 <filter
                     string="Due Within 30 Days"
-                    domain="[
-                    ('scheduled_date_start', '&gt;=',(datetime.datetime.combine(datetime.date.today(), datetime.time(0,0,0)))),
-                    ('scheduled_date_start', '&lt;=', (datetime.datetime.combine((datetime.date.today()+relativedelta(days=29)), datetime.time(23,59,59))))
-                    ]"
                     name="order_upcoming_month"
+                    domain="[
+                            ('date_today_order_tz', '&gt;=', context_today()),
+                            ('date_today_order_tz', '&lt;=', (context_today() + relativedelta(days=29)))
+                        ]"
                 />
+
                 <filter
                     string="Due This Week"
                     name="this_week_orders"
-                    domain="[('scheduled_date_start', '&lt;=', ((context_today()+relativedelta(weeks=0, weekday=-1)).strftime('%Y-%m-%d'))),
-                    ('scheduled_date_start', '&gt;=', ((context_today()-relativedelta(weeks=1, weekday=0)).strftime('%Y-%m-%d')))]"
+                    domain="[('date_today_order_tz', '&lt;=', ((context_today()+relativedelta(weeks=0, weekday=-1)).strftime('%Y-%m-%d'))),
+                    ('date_today_order_tz', '&gt;=', ((context_today()-relativedelta(weeks=1, weekday=0)).strftime('%Y-%m-%d')))]"
                 />
                 <separator />
                 <group expand="0" string="Group By">


### PR DESCRIPTION
This commit introduces date_today_order_tz computed field in the `fsm.order` model
to enable accurate filtering of orders based on the user's timezone.

These fields allow view filters (e.g., "Today Orders") to function
correctly regardless of timezone, addressing the limitation where
UTC-stored datetimes cause inconsistencies in local time filtering.

cc https://github.com/APSL 13151

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review