### PR TITLE
[17.0][IMP] fieldservice_route_availability: Consider ZIP code on blackout days for precise availability validation

### DIFF
--- a/fieldservice_route_availability/README.rst
+++ b/fieldservice_route_availability/README.rst
@@ -67,9 +67,9 @@ Authors
 Contributors
 ------------
 
-- `APSL-Nagarro <https://www.apsl.tech>`__:
+-  `APSL-Nagarro <https://www.apsl.tech>`__:
 
-  - Antoni Marroig <amarroig@apsl.net>
+   -  Antoni Marroig <amarroig@apsl.net>
 
 Maintainers
 -----------

--- a/fieldservice_route_availability/__manifest__.py
+++ b/fieldservice_route_availability/__manifest__.py
@@ -17,5 +17,6 @@
     ],
     "data": [
         "views/fsm_route.xml",
+        "views/fsm_blackout_day_templates.xml",
     ],
 }

--- a/fieldservice_route_availability/models/__init__.py
+++ b/fieldservice_route_availability/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import fsm_route
 from . import fsm_order
+from . import fsm_blackout_day

--- a/fieldservice_route_availability/models/fsm_blackout_day.py
+++ b/fieldservice_route_availability/models/fsm_blackout_day.py
@@ -1,0 +1,12 @@
+# Copyright 2025 APSL-Nagarro Bernat Obrador
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class FieldServiceBlackoutDay(models.Model):
+    _inherit = "fsm.blackout.day"
+
+    zip = fields.Char(
+        help="Postal code of the blackout day.",
+    )

--- a/fieldservice_route_availability/models/fsm_order.py
+++ b/fieldservice_route_availability/models/fsm_order.py
@@ -8,20 +8,26 @@ from odoo.exceptions import ValidationError
 class FSMRoute(models.Model):
     _inherit = "fsm.order"
 
-    @api.constrains("fsm_route_id", "scheduled_date_start")
+    @api.constrains("fsm_route_id", "scheduled_date_start", "location_id")
     def check_black_out_days(self):
         for order in self:
             if order.fsm_route_id and order.scheduled_date_start:
                 for group in order.fsm_route_id.fsm_blackout_group_ids:
                     match = group.fsm_blackout_day_ids.filtered(
-                        lambda x, order=order: x.date
-                        == order.scheduled_date_start.date()
+                        lambda x, order=order: (
+                            (not x.zip and x.date == order.scheduled_date_start.date())
+                            or (
+                                x.zip
+                                and x.date == order.scheduled_date_start.date()
+                                and x.zip == order.zip
+                            )
+                        )
                     )
                     if match:
                         raise ValidationError(
                             _(
                                 "The date %(date)s is a blackout day for field"
-                                " service operations on this route"
+                                " service operations on this route."
                             )
                             % {
                                 "date": order.scheduled_date_start.date().strftime(

--- a/fieldservice_route_availability/tests/test_route_availability.py
+++ b/fieldservice_route_availability/tests/test_route_availability.py
@@ -51,3 +51,19 @@ class TestRouteAvailability(common.TransactionCase):
             order_form.save()
         order_form.scheduled_date_start = fields.Datetime.today() + timedelta(days=1)
         self.assertTrue(order_form.save())
+
+    def test_validate_blackout_days_with_zip(self):
+        self.blackout_group.fsm_blackout_day_ids[0].zip = "12345"
+
+        self.test_location.zip = "12345"
+        order_form = Form(self.env["fsm.order"])
+        order_form.location_id = self.test_location
+        order_form.scheduled_date_start = fields.Datetime.today()
+        with self.assertRaises(ValidationError):
+            order_form.save()
+
+        self.test_location.zip = "99999"
+        order_form = Form(self.env["fsm.order"])
+        order_form.location_id = self.test_location
+        order_form.scheduled_date_start = fields.Datetime.today()
+        self.assertTrue(order_form.save())

--- a/fieldservice_route_availability/views/fsm_blackout_day_templates.xml
+++ b/fieldservice_route_availability/views/fsm_blackout_day_templates.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_fsm_blackout_day_tree_inherit" model="ir.ui.view">
+        <field name="name">fsm.blackout.day.tree.inhetir</field>
+        <field name="model">fsm.blackout.day</field>
+        <field
+            name="inherit_id"
+            ref="fieldservice_availability.view_fsm_blackout_day_tree"
+        />
+        <field name="arch" type="xml">
+
+            <xpath expr="//field[@name='date']" position="after">
+                <field name="zip" />
+            </xpath>
+        </field>
+    </record>
+    <record id="view_fsm_blackout_day_form_inherit" model="ir.ui.view">
+        <field name="name">fsm.blackout.day.form.inhetir</field>
+        <field name="model">fsm.blackout.day</field>
+        <field
+            name="inherit_id"
+            ref="fieldservice_availability.view_fsm_blackout_day_form"
+        />
+        <field name="arch" type="xml">
+
+            <xpath expr="//field[@name='date']" position="after">
+                <field name="zip" />
+            </xpath>
+        </field>
+    </record>
+    <record id="view_fsm_blackout_group_form_inherit" model="ir.ui.view">
+        <field name="name">fsm.blackout.group.form.inhetir</field>
+        <field name="model">fsm.blackout.group</field>
+        <field
+            name="inherit_id"
+            ref="fieldservice_availability.view_fsm_blackout_group_form"
+        />
+        <field name="arch" type="xml">
+
+            <xpath expr="//tree/field[@name='date']" position="after">
+                <field name="zip" />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This improvement adds the ZIP field to blackout days and uses it to validate scheduled start dates. 
If the ZIP is set, the blackout applies only to matching service orders. 
If not set, the blackout applies globally by date.

cc https://github.com/APSL 13569

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review