### PR TITLE
[17.0][IMP] fieldservice: Enable search by categories and related owner of the location

### DIFF
--- a/fieldservice/i18n/es.po
+++ b/fieldservice/i18n/es.po
@@ -1992,6 +1992,11 @@ msgid "Location Phone"
 msgstr "Teléfono de Ubicación"
 
 #. module: fieldservice
+#: model:ir.model.fields,field_description:fieldservice.field_fsm_order__location_owner_id
+msgid "Location Related Owner"
+msgstr "Propietario relacionado de la ubicación"
+
+#. module: fieldservice
 #: model_terms:ir.actions.act_window,help:fieldservice.action_fsm_report_location
 msgid "Location Reports."
 msgstr "Reportes de Ubicación."

--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -114,6 +114,9 @@ class FSMOrder(models.Model):
     location_id = fields.Many2one(
         "fsm.location", string="Location", index=True, required=True
     )
+    location_owner_id = fields.Many2one(
+        related="location_id.owner_id", string="Location Related Owner"
+    )
     location_directions = fields.Html()
     request_early = fields.Datetime(
         string="Earliest Request Date", default=datetime.now()

--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -348,6 +348,8 @@
                     string="FSM Order Name"
                 />
                 <field name="location_id" />
+                <field name="location_owner_id" />
+                <field name="category_ids" />
                 <field name="branch_id" />
                 <field name="district_id" />
                 <field name="region_id" />


### PR DESCRIPTION
Enable search by categories and for the related owner name of the location.

cc https://github.com/APSL 15592
@miquelalzanillas @javierobcn @mpascuall @BernatObrador @ppyczko @lbarry-apsl please review

