### PR TITLE
[16.0][IMP] fieldservice: Allow to archive FSM Teams

### DIFF
--- a/fieldservice/models/fsm_team.py
+++ b/fieldservice/models/fsm_team.py
@@ -52,6 +52,7 @@ class FSMTeam(models.Model):
 
     name = fields.Char(required=True, translate=True)
     description = fields.Text(translate=True)
+    active = fields.Boolean(default=True)
     color = fields.Integer("Color Index")
     stage_ids = fields.Many2many(
         "fsm.stage",

--- a/fieldservice/views/fsm_team.xml
+++ b/fieldservice/views/fsm_team.xml
@@ -12,6 +12,12 @@
         <field name="arch" type="xml">
             <form string="Order Team">
                 <sheet>
+                    <widget
+                        name="web_ribbon"
+                        title="Archived"
+                        bg_color="bg-danger"
+                        attrs="{'invisible': [('active', '=', True)]}"
+                    />
                     <div class="oe_title">
                         <label for="name" class="oe_edit_only" string="Team Name" />
                         <h1>
@@ -20,6 +26,7 @@
                     </div>
                     <group>
                         <group>
+                            <field name="active" invisible="1" />
                             <field name="description" colspan="2" />
                             <field name="sequence" />
                         </group>
@@ -252,6 +259,20 @@
                     </t>
                 </templates>
             </kanban>
+        </field>
+    </record>
+    <record id="view_team_search" model="ir.ui.view">
+        <field name="name">fsm.team.search</field>
+        <field name="model">fsm.team</field>
+        <field name="arch" type="xml">
+            <search string="Search FSM Teams">
+                <field name="name" />
+                <filter
+                    string="Archived"
+                    name="inactive"
+                    domain="[('active', '=', False)]"
+                />
+            </search>
         </field>
     </record>
     <record id="action_team_dashboard" model="ir.actions.act_window">


### PR DESCRIPTION
Add possibility to archive Teams in "Plant Monitoring > Configuration > Field Service Teams".
If a record is archived, a `web_ribbon` will show the archived state in the related Form view.
Add also a filter to search all archived records.