### PR TITLE
[16.0][IMP] fieldservice_geoengine: Legends based on attribute_field_id

### DIFF
--- a/fieldservice_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
+++ b/fieldservice_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
@@ -62,11 +62,13 @@ patch(GeoengineRenderer.prototype, "geoengine_renderer_view_patch", {
         let legend = null;
         if (vals.length <= LEGEND_MAX_ITEMS) {
             legend = serie.getHtmlLegend(colors, cfg.name, 1);
-            for (let i = 0; i < data.length; i++) {
-                legend = legend.replace(
-                    data[i]._values[cfg.attribute_field_id[1]],
-                    data[i]._values.stage_name
-                );
+            if (indicator === "custom_color") {
+                for (let i = 0; i < data.length; i++) {
+                    legend = legend.replace(
+                        data[i]._values[cfg.attribute_field_id[1]],
+                        data[i]._values.stage_name
+                    );
+                }
             }
         }
         return {


### PR DESCRIPTION
   When "attribute_field_id" of geoengine data is configured
with other than "stage_name" field, legends are not displayed based on fields configured.
   Replacing legend is required only for "custom_color" as legend
needs to be displayed based on "stage_name", if not legend points to "custom_color" as value in geoengine map view.