### PR TITLE
[18.0] [IMP/FIX] `fieldservice_equipment_stock`: product.template.create_fsm_equipment UX

### DIFF
--- a/fieldservice_equipment_stock/models/product_template.py
+++ b/fieldservice_equipment_stock/models/product_template.py
@@ -7,4 +7,9 @@ from odoo import fields, models
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    create_fsm_equipment = fields.Boolean(string="Creates a FSM Equipment")
+    create_fsm_equipment = fields.Boolean(
+        string="Creates a FSM Equipment",
+        help="Creates a Field Service Equipment when a stock move is done. "
+        "It requires the 'Create FSM Equipment' option to be enabled on the "
+        "picking type, too.",
+    )

--- a/fieldservice_equipment_stock/views/product_template.xml
+++ b/fieldservice_equipment_stock/views/product_template.xml
@@ -3,7 +3,7 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_only_form_view" />
         <field name="arch" type="xml">
-            <group name="traceability" position="inside">
+            <group name="group_general" position="inside">
                 <field name="create_fsm_equipment" invisible="tracking != 'serial'" />
             </group>
         </field>

--- a/fieldservice_equipment_stock/views/product_template.xml
+++ b/fieldservice_equipment_stock/views/product_template.xml
@@ -4,7 +4,11 @@
         <field name="inherit_id" ref="product.product_template_only_form_view" />
         <field name="arch" type="xml">
             <group name="group_general" position="inside">
-                <field name="create_fsm_equipment" invisible="tracking != 'serial'" />
+                <field
+                    name="create_fsm_equipment"
+                    groups="fieldservice.group_fsm_user"
+                    invisible="tracking != 'serial'"
+                />
             </group>
         </field>
     </record>


### PR DESCRIPTION
Moves the field to the general setting, so that it's visible even if the traceability group is hidden.
Otherwise it's impossible to configure it.

<img width="2510" height="1636" alt="image" src="https://github.com/user-attachments/assets/98bb5143-9b9a-4958-ac2a-7a12ceb50c5e" />


Also added a field description