### PR TITLE
[18.0][FIX] fsm.order.todo displays HTML tags in Qweb report

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -177,7 +177,7 @@ class FSMOrder(models.Model):
     scheduled_duration = fields.Float(help="Scheduled duration of the work in" " hours")
     scheduled_date_end = fields.Datetime(string="Scheduled End")
     sequence = fields.Integer(default=10)
-    todo = fields.Text(
+    todo = fields.Html(
         string="Instructions",
         compute="_compute_todo",
         precompute=True,

--- a/fieldservice/models/fsm_template.py
+++ b/fieldservice/models/fsm_template.py
@@ -9,7 +9,7 @@ class FSMTemplate(models.Model):
     _description = "Field Service Order Template"
 
     name = fields.Char(required=True)
-    instructions = fields.Text()
+    instructions = fields.Html()
     category_ids = fields.Many2many("fsm.category", string="Categories")
     duration = fields.Float(help="Default duration in hours")
     company_id = fields.Many2one(

--- a/fieldservice/report/fsm_order_report_template.xml
+++ b/fieldservice/report/fsm_order_report_template.xml
@@ -39,9 +39,9 @@
                     <h3>Description</h3>
                     <p t-field="doc.description" />
                 </div>
-                <div t-if="doc.todo" id="instruction">
+                <div t-if="not is_html_empty(doc.todo)" id="instruction">
                     <h3>Instructions</h3>
-                    <p t-out="doc.todo" />
+                    <p t-field="doc.todo" />
                 </div>
                 <div t-if="doc.resolution" id="resolution">
                     <h3>Resolution Notes</h3>


### PR DESCRIPTION
### in ``fieldservice.report_fsm_order_document``:

#### Before
<img width="424" height="373" alt="Screenshot from 2025-09-11 09-16-13" src="https://github.com/user-attachments/assets/878ec1aa-69ea-4965-8db9-44365f768f81" />

#### After
<img width="424" height="373" alt="image" src="https://github.com/user-attachments/assets/333feae5-9bf3-4478-9546-a4da565f46d3" />
