### PR TITLE
[18.0][FIX] fieldservice: fsm.order::onchange_template_id must be public

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -421,7 +421,7 @@ class FSMOrder(models.Model):
             self.scheduled_date_end = self.scheduled_date_start
 
     @api.onchange("template_id")
-    def _onchange_template_id(self):
+    def onchange_template_id(self):
         if self.template_id:
             self.category_ids = self.template_id.category_ids
             self.scheduled_duration = self.template_id.duration

--- a/fieldservice/tests/test_fsm_order_template_onchange.py
+++ b/fieldservice/tests/test_fsm_order_template_onchange.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2019 Brian McMaster <brian@mcmpest.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import fields
+from odoo import Command, fields
+from odoo.tests import Form
 
 from . import test_fsm_order
 
@@ -19,9 +20,7 @@ class TestTemplateOnchange(test_fsm_order.TestFSMOrder):
         - Category IDs, Scheduled Duration,and Type should update
         - The instructions should be copied
         """
-        categories = []
-        categories.append(self.fsm_category_a.id)
-        categories.append(self.fsm_category_b.id)
+        categories = [self.fsm_category_a.id, self.fsm_category_b.id]
         self.fsm_template_1 = self.env["fsm.template"].create(
             {
                 "name": "Test FSM Template #1",
@@ -33,33 +32,39 @@ class TestTemplateOnchange(test_fsm_order.TestFSMOrder):
         )
         self.fsm_template_2 = self.env["fsm.template"].create(
             {
-                "name": "Test FSM Template #1",
-                "instructions": "These are the instructions for Template #1",
+                "name": "Test FSM Template #2",
+                "instructions": "These are the instructions for Template #2",
                 "category_ids": [(6, 0, categories)],
                 "duration": 2.25,
                 "team_id": self.fsm_team_a.id,
             }
         )
-        self.fso = self.Order.create(
+        self.env.user.write(
             {
-                "location_id": self.test_location.id,
-                "template_id": self.fsm_template_1.id,
-                "scheduled_date_start": fields.Datetime.today(),
+                "groups_id": [
+                    Command.link(self.env.ref("fieldservice.group_fsm_template").id),
+                    Command.link(self.env.ref("fieldservice.group_fsm_category").id),
+                ]
             }
         )
-        self.fso2 = self.Order.create(
-            {
-                "location_id": self.test_location.id,
-                "template_id": self.fsm_template_2.id,
-                "scheduled_date_start": fields.Datetime.today(),
-            }
-        )
-        self.fso._onchange_template_id()
-        self.fso2._onchange_template_id()
-        self.assertEqual(
-            self.fso.category_ids.ids, self.fsm_template_1.category_ids.ids
-        )
-        self.assertEqual(self.fso.scheduled_duration, self.fsm_template_1.duration)
-        self.assertEqual(self.fso.type.id, self.fsm_template_1.type_id.id)
-        self.assertEqual(self.fso.todo, self.fsm_template_1.instructions)
-        self.assertEqual(self.fso2.team_id.id, self.fsm_team_a.id)
+        default_team = self.Order._default_team_id()
+        with Form(self.Order, view="fieldservice.fsm_order_form") as f:
+            f.location_id = self.test_location
+            f.scheduled_date_start = fields.Datetime.today()
+            f.template_id = self.fsm_template_1
+            self.assertEqual(f.category_ids.ids, self.fsm_template_1.category_ids.ids)
+            self.assertEqual(f.scheduled_duration, self.fsm_template_1.duration)
+            self.assertEqual(f.type.id, self.fsm_template_1.type_id.id)
+            self.assertEqual(f.todo, self.fsm_template_1.instructions)
+            # Team should be the default one since template 1 has no team
+            self.assertEqual(f.team_id.id, default_team.id)
+
+            # Change the template
+            f.template_id = self.fsm_template_2
+            self.assertEqual(f.category_ids.ids, self.fsm_template_2.category_ids.ids)
+            self.assertEqual(f.scheduled_duration, self.fsm_template_2.duration)
+            # Type should remain the same since template 2 has no type
+            self.assertEqual(f.type.id, self.fsm_type_a.id)
+            self.assertEqual(f.todo, self.fsm_template_2.instructions)
+            # Team should be changed since template 2 has a team
+            self.assertEqual(f.team_id.id, self.fsm_template_2.team_id.id)

--- a/fieldservice_activity/models/fsm_order.py
+++ b/fieldservice_activity/models/fsm_order.py
@@ -45,7 +45,7 @@ class FSMOrder(models.Model):
         """Update Activities for FSM orders that are generate from SO"""
         orders = super().create(vals)
         for order in orders:
-            order._onchange_template_id()
+            order.onchange_template_id()
         return orders
 
     def action_complete(self):

--- a/fieldservice_activity/tests/test_fsm_activity.py
+++ b/fieldservice_activity/tests/test_fsm_activity.py
@@ -136,8 +136,8 @@ class TestFSMActivity(TransactionCase):
         self.fso = self.Order.create(
             {"location_id": self.test_location.id, "template_id": self.template.id}
         )
-        # Test _onchange_template_id()
-        self.fso._onchange_template_id()
+        # Test onchange_template_id()
+        self.fso.onchange_template_id()
         self.assertNotEqual(
             self.fso.order_activity_ids.ids, self.fso.template_id.temp_activity_ids.ids
         )

--- a/fieldservice_recurring/models/fsm_recurring.py
+++ b/fieldservice_recurring/models/fsm_recurring.py
@@ -205,7 +205,7 @@ class FSMRecurringOrder(models.Model):
         self.ensure_one()
         vals = self._prepare_order_values(date)
         order = self.env["fsm.order"].create(vals)
-        order._onchange_template_id()
+        order.onchange_template_id()
         return order
 
     def _generate_orders(self):


### PR DESCRIPTION
`_onchange_template_id` is not triggered **on the UI**, whereas `onchange_template_id` is.