### PR TITLE
[16.0][IMP] fieldservice_geoengine: Fix vector Layer related Errors

### DIFF
--- a/fieldservice_geoengine/models/vector_layer.py
+++ b/fieldservice_geoengine/models/vector_layer.py
@@ -7,6 +7,18 @@ from odoo import _, api, models
 from odoo.exceptions import ValidationError
 
 NUMBER_ATT = ["float", "integer", "integer_big"]
+SUPPORTED_ATT = [
+    "float",
+    "integer",
+    "integer_big",
+    "related",
+    "function",
+    "date",
+    "datetime",
+    "char",
+    "text",
+    "selection",
+]
 
 
 class GeoVectorLayer(models.Model):
@@ -31,3 +43,23 @@ class GeoVectorLayer(models.Model):
                             "You need to select a numeric field",
                         )
                     )
+
+    @api.depends("geo_field_id", "classification", "geo_repr")
+    def _compute_attribute_field_id_domain(self):
+        for rec in self:
+            if rec.geo_field_id:
+                if (
+                    rec.geo_repr == "colored"
+                    and rec.classification not in ("unique", "custom")
+                ) or rec.geo_repr == "proportion":
+                    rec.attribute_field_id_domain = [
+                        ("ttype", "in", NUMBER_ATT),
+                        ("model", "=", rec.geo_field_id.model_id.model),
+                    ]
+                else:
+                    rec.attribute_field_id_domain = [
+                        ("ttype", "in", SUPPORTED_ATT),
+                        ("model", "=", rec.geo_field_id.model_id.model),
+                    ]
+            else:
+                rec.attribute_field_id_domain = [("ttype", "in", SUPPORTED_ATT)]

--- a/fieldservice_geoengine/oca_dependencies.txt
+++ b/fieldservice_geoengine/oca_dependencies.txt
@@ -1,0 +1,1 @@
+geospatial https://github.com/OCA/geospatial refs/pull/417/head 9825f67d128918294b67b74d324d1e6d3259399b

--- a/fieldservice_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
+++ b/fieldservice_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
@@ -34,6 +34,23 @@ patch(GeoengineRenderer.prototype, "geoengine_renderer_view_patch", {
             case "unique":
             case "custom":
                 vals = serie.getClassUniqueValues();
+                if (
+                    cfg.classification === "custom" &&
+                    vals.some((item) => item === 0)
+                ) {
+                    this.notification.add(
+                        this.env._t(
+                            "Could not generate " +
+                                cfg.classification +
+                                " range for selected Attribute Field: " +
+                                indicator
+                        ),
+                        {
+                            type: "warning",
+                        }
+                    );
+                    return false;
+                }
                 // "RdYlBu" is a set of colors
                 scale = chroma.scale("RdYlBu").domain([0, vals.length], vals.length);
                 break;
@@ -45,6 +62,18 @@ patch(GeoengineRenderer.prototype, "geoengine_renderer_view_patch", {
             case "interval":
                 serie.getClassEqInterval(nb_class);
                 vals = serie.getRanges();
+                if (vals.some((item) => item === "0 - 0")) {
+                    this.notification.add(
+                        this.env._t(
+                            "Could not generate interval range for selected Attribute Field: " +
+                                indicator
+                        ),
+                        {
+                            type: "warning",
+                        }
+                    );
+                    return false;
+                }
                 scale = scale.domain([0, vals.length], vals.length);
                 break;
         }
@@ -81,7 +110,13 @@ patch(GeoengineRenderer.prototype, "geoengine_renderer_view_patch", {
                 } else if (label_text !== "") {
                     label_text = feature.values_.attributes.stage_name;
                 }
-                styles_map[colors[color_idx]][0].text_.text_ = label_text.toString();
+                try {
+                    styles_map[colors[color_idx]][0].text_.text_ =
+                        label_text.toString();
+                } catch (error) {
+                    // Do nothing to restore history
+                    return;
+                }
                 return styles_map[colors[color_idx]];
             },
             legend,
@@ -134,8 +169,39 @@ patch(GeoengineRenderer.prototype, "geoengine_renderer_view_patch", {
             }
             aux.push(data[i]);
         }
-        const styleInfo = this.styleVectorLayer(cfg, aux);
-        this.initLegend(styleInfo, cfg);
-        lv.setStyle(styleInfo.style);
+        if (this.checkAttributeFieldUsage(cfg, aux)) {
+            const styleInfo = this.styleVectorLayer(cfg, aux);
+            if (styleInfo) {
+                this.initLegend(styleInfo, cfg);
+                lv.setStyle(styleInfo.style);
+            }
+        }
+    },
+    /**
+     * Allows you to find the index of the color to be used according to its value.
+     * @param {*} val
+     * @param {*} a
+     * @returns {Number}
+     */
+    getClass(val, a) {
+        // Classification uniqueValues
+        var idx = a.indexOf(val);
+        if (idx > -1) {
+            return idx;
+        }
+        // Range classification
+        var separator = " - ";
+        for (var i = 0; i < a.length; i++) {
+            // All classification except uniqueValues
+            if (typeof val !== "object" && a[i].indexOf(separator) !== -1) {
+                var item = a[i].split(separator);
+                if (val <= parseFloat(item[1])) {
+                    return i;
+                }
+            } else if (val === a[i]) {
+                // Classification uniqueValues
+                return i;
+            }
+        }
     },
 });


### PR DESCRIPTION
- [ ] Depends on base_geoengine PR [#417](https://github.com/OCA/geospatial/pull/417#top)

Domain for "attribute_field_id" is filtered based on "classification" field selection in vector layer, which helps to avoid JS error seen as "fsm.order" and "fsm.location" related fields are not validated based on "NUM_ATT" types.[ base_geoengine_validation](https://github.com/OCA/geospatial/blob/16.0/base_geoengine/models/geo_vector_layer.py#L122).

   Notifying user to define selected field from attribute_field_id of supported type in geoengine view which avoids below JS error observed:
   <img width="1429" height="636" alt="Screenshot from 2025-10-08 17-09-18" src="https://github.com/user-attachments/assets/7c02c96f-5f3b-46ae-83d5-72c522be9d83" />

   Notifying users when a field of supported type from attribute_field_id is not suitable to use for classification type "custom" which avoids below observed JS Error:
   <img width="1474" height="851" alt="image" src="https://github.com/user-attachments/assets/6c0d52fd-d3df-4a87-a7c0-a2553ecb37b1" />
   
  As  fieldservice_geoengine omits validation for custom classification related to "type" check on field selected in "attribute_field_id", when user selects fields of type "date" with "custom", below JS error observed:
   <img width="1901" height="952" alt="image" src="https://github.com/user-attachments/assets/aee2f712-4cc0-4e50-abb4-23876b2478fb" />

  