### PR TITLE
[17.0] [FIX] fieldservice_recurring: order creation vals

### DIFF
--- a/fieldservice_recurring/models/fsm_recurring.py
+++ b/fieldservice_recurring/models/fsm_recurring.py
@@ -192,7 +192,7 @@ class FSMRecurringOrder(models.Model):
         return {
             "fsm_recurring_id": self.id,
             "location_id": self.location_id.id,
-            "team_id": self.team_id.id,
+            "team_id": self.team_id.id or self.fsm_order_template_id.team_id.id,
             "scheduled_date_start": schedule_date,
             "request_early": str(earliest_date),
             "description": self.description,
@@ -202,13 +202,15 @@ class FSMRecurringOrder(models.Model):
             "company_id": self.company_id.id,
             "person_id": self.person_id.id,
             "equipment_ids": [(6, 0, self.equipment_ids.ids)],
+            "type": self.fsm_order_template_id.type_id.id,
         }
 
     def _create_order(self, date):
         self.ensure_one()
         vals = self._prepare_order_values(date)
         order = self.env["fsm.order"].create(vals)
-        order._onchange_template_id()
+        if order.template_id:
+            order.copy_notes()
         return order
 
     def _generate_orders(self):

--- a/fieldservice_recurring/tests/test_fsm_recurring.py
+++ b/fieldservice_recurring/tests/test_fsm_recurring.py
@@ -19,6 +19,7 @@ class FSMRecurringCase(TransactionCase):
         cls.Recurring = cls.env["fsm.recurring"]
         cls.Frequency = cls.env["fsm.frequency"]
         cls.FrequencySet = cls.env["fsm.frequency.set"]
+        cls.OrderTemplate = cls.env["fsm.template"]
         # create a Partner to be converted to FSM Location/Person
         cls.test_loc_partner = cls.env["res.partner"].create(
             {"name": "Test Loc Partner", "phone": "ABC", "email": "tlp@email.com"}
@@ -307,3 +308,27 @@ class FSMRecurringCase(TransactionCase):
         fsm_order = self.env["fsm.order"].create(order_vals)
         self.env["fsm.order"].create(order_vals2)
         fsm_order.action_view_fsm_recurring()
+
+    def test_fsm_order_vals_from_template(self):
+        order_template = self.OrderTemplate.create(
+            {
+                "name": "Order Template",
+                "instructions": "Instructions for the order template",
+                "duration": 1.5,
+            }
+        )
+        recurring = self.Recurring.create(
+            {
+                "fsm_frequency_set_id": self.fr_set.id,
+                "location_id": self.test_location.id,
+                "start_date": fields.Datetime.now().replace(hour=12),
+                "fsm_order_template_id": order_template.id,
+                "scheduled_duration": 2.0,
+            }
+        )
+        recurring.action_start()
+        order = recurring.fsm_order_ids[0]
+        # Test the template instructions were added on order
+        self.assertEqual(order.todo, order_template.instructions)
+        # Test the duration is set to the RFO duration (not the template)
+        self.assertEqual(order.scheduled_duration, recurring.scheduled_duration)


### PR DESCRIPTION
This change prevents calling `fsm_order._onchange_template_id()` right after creating a new `fsm_order` from the `fsm_recurring`

Previously, the `scheduled_duration` and `team_id` fields were set to the order template value in the onchange method, which changes the value initially returned by the `fsm_recurring._prepare_order_values()` method.
