### PR TITLE
[16.0] [FIX] fieldservice_activity multiple bugs

### DIFF
--- a/fieldservice_activity/models/fsm_order.py
+++ b/fieldservice_activity/models/fsm_order.py
@@ -51,5 +51,4 @@ class FSMOrder(models.Model):
                     )
                     % activity.name
                 )
-        self.activity_ids._action_done()
         return res

--- a/fieldservice_activity/models/fsm_order.py
+++ b/fieldservice_activity/models/fsm_order.py
@@ -40,14 +40,6 @@ class FSMOrder(models.Model):
 
             rec.order_activity_ids = activity_list
 
-    @api.model_create_multi
-    def create(self, vals):
-        """Update Activities for FSM orders that are generate from SO"""
-        orders = super(FSMOrder, self).create(vals)
-        for order in orders:
-            order._onchange_template_id()
-        return orders
-
     def action_complete(self):
         res = super().action_complete()
         for activity in self.order_activity_ids:

--- a/fieldservice_activity/tests/test_fsm_activity.py
+++ b/fieldservice_activity/tests/test_fsm_activity.py
@@ -112,7 +112,7 @@ class TestFSMActivity(TransactionCase):
             "fsm_order_id": order_id,
         }
 
-    def test_onchange_template_id(self):
+    def test_compute_order_activity_ids(self):
         # Create a Template
         self.template = self.template_obj.create(
             {
@@ -135,8 +135,24 @@ class TestFSMActivity(TransactionCase):
         self.fso = self.Order.create(
             {"location_id": self.test_location.id, "template_id": self.template.id}
         )
-        # Test _onchange_template_id()
-        self.fso._onchange_template_id()
-        self.assertNotEqual(
-            self.fso.order_activity_ids.ids, self.fso.template_id.temp_activity_ids.ids
+        # Test FSM Order has FSM Activity based on the FSM Template
+        self.assertEqual(
+            len(self.fso.order_activity_ids),
+            len(self.fso.template_id.temp_activity_ids),
+            "Amount of FSM Activites on FSM Order should be the same as FSM Template",
+        )
+        self.assertEqual(
+            self.fso.order_activity_ids[0].name,
+            self.fso.template_id.temp_activity_ids[0].name,
+            "Name of FSM Activity on FSM Order should match FSM Template",
+        )
+        self.assertEqual(
+            self.fso.order_activity_ids[0].required,
+            self.fso.template_id.temp_activity_ids[0].required,
+            "Required field of FSM Activity on FSM Order should match FSM Template",
+        )
+        self.assertEqual(
+            self.fso.order_activity_ids[0].ref,
+            self.fso.template_id.temp_activity_ids[0].ref,
+            "Reference of FSM Activity on FSM Order should match FSM Template",
         )

--- a/fieldservice_activity/tests/test_fsm_activity.py
+++ b/fieldservice_activity/tests/test_fsm_activity.py
@@ -53,16 +53,6 @@ class TestFSMActivity(TransactionCase):
             }
         )
         order_id = order.id
-        activity_id = self.env["mail.activity"].create(
-            {
-                "summary": "Meeting with partner",
-                "activity_type_id": self.activty_type.id,
-                "res_model_id": self.env["ir.model"]._get("fsm.order").id,
-                "res_id": order2.id,
-                "user_id": self.env.user.id,
-            }
-        )
-        order2.activity_ids = [(6, False, activity_id.ids)]
         self.Activity.create(
             self.get_activity_vals("Activity Test", False, "Ref 1", order2.id)
         )


### PR DESCRIPTION
Bug introduced during migration to 16.0:
There is no longer a reason to call the `fsm_order.onchange_template_id()` method since the FSM Activity field is now computed and depends on the order `template_id`

Additionally, this module should not close any `order.activity_ids` which is the `mail.activity` model, not the `fsm.activity` model of this module