### PR TITLE
[18.0] [FIX] fieldservice: idempotent create missing fsm location

### DIFF
--- a/fieldservice/models/res_partner.py
+++ b/fieldservice/models/res_partner.py
@@ -10,7 +10,7 @@ class ResPartner(models.Model):
     type = fields.Selection(selection_add=[("fsm_location", "Location")])
     fsm_location = fields.Boolean("Is a FS Location")
     fsm_person = fields.Boolean("Is a FS Worker")
-    fsm_location_id = fields.One2many(
+    fsm_location_ids = fields.One2many(
         comodel_name="fsm.location",
         string="Related FS Location",
         inverse_name="partner_id",

--- a/fieldservice/models/res_partner.py
+++ b/fieldservice/models/res_partner.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018 - TODAY, Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
@@ -51,22 +51,23 @@ class ResPartner(models.Model):
                 action["res_id"] = owned_location_ids.ids[0]
             return action
 
-    def _convert_fsm_location(self):
-        wiz = self.env["fsm.wizard"]
-        partners_with_loc_ids = (
-            self.env["fsm.location"]
-            .sudo()
-            .search([("active", "in", [False, True]), ("partner_id", "in", self.ids)])
-            .mapped("partner_id")
-        ).ids
+    def _create_missing_fsm_location(self):
+        for rec in self:
+            if rec.type != "fsm_location":
+                continue
+            if not rec.fsm_location_ids:
+                self.env["fsm.wizard"].action_convert_location(rec)
 
-        partners_to_convert = self.filtered(
-            lambda p: p.type == "fsm_location" and p.id not in partners_with_loc_ids
-        )
-        for partner_to_convert in partners_to_convert:
-            wiz.action_convert_location(partner_to_convert)
-
-    def write(self, value):
-        res = super().write(value)
-        self._convert_fsm_location()
+    def write(self, vals):
+        # OVERRIDE to create the fsm.location for partners of type = fsm_location
+        res = super().write(vals)
+        if "type" in vals:
+            self._create_missing_fsm_location()
         return res
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # OVERRIDE to create the fsm.location for partners of type = fsm_location
+        records = super().create(vals_list)
+        records._create_missing_fsm_location()
+        return records

--- a/fieldservice/tests/test_fsm_location.py
+++ b/fieldservice/tests/test_fsm_location.py
@@ -243,11 +243,9 @@ class FSMLocation(TransactionCase):
         child_loc = self.env["res.partner"].create(vals)
 
         self.assertTrue(child_loc.fsm_location, "fsm_location Flag should be set")
-        self.assertTrue(
-            child_loc.fsm_location_id.exists(), "fsm.location should exists"
-        )
+        self.assertTrue(child_loc.fsm_location_ids, "fsm.location should exist")
         self.assertEqual(
-            child_loc.fsm_location_id.partner_id,
+            child_loc.fsm_location_ids.partner_id,
             child_loc,
             "ensure circular references",
         )


### PR DESCRIPTION
Without this, it can cause a recursion error:

```
  File "/odoo/odoo/external-src/field-service/fieldservice/models/fsm_location.py", line 80, in create
    res = super().create(vals)
          ^^^^^^^^^^^^^^^^^^^^
  File "<decorator-gen-53>", line 2, in create
  File "/odoo/src/odoo/odoo/api.py", line 498, in _model_create_multi
    return create(self, arg)
           ^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/addons/mail/models/mail_thread.py", line 278, in create
    threads = super(MailThread, self).create(vals_list)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<decorator-gen-0>", line 2, in create
  File "/odoo/src/odoo/odoo/api.py", line 498, in _model_create_multi
    return create(self, arg)
           ^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/odoo/models.py", line 4979, in create
    new_vals_list = self._prepare_create_values(vals_list)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/odoo/models.py", line 5122, in _prepare_create_values
    vals = self._add_missing_default_values(vals)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/odoo/models.py", line 1929, in _add_missing_default_values
    defaults = self.default_get(missing_defaults)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/odoo/models.py", line 1653, in default_get
    ir_defaults = self.env['ir.default']._get_model_defaults(self._name)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/.venv/lib/python3.12/site-packages/decorator.py", line 231, in fun
    args, kw = fix(args, kw, sig)
               ^^^^^^^^^^^^^^^^^^
  File "/odoo/.venv/lib/python3.12/site-packages/decorator.py", line 203, in fix
    ba = sig.bind(*args, **kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/inspect.py", line 3280, in bind
    return self._bind(args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
RecursionError: maximum recursion depth exceeded
```