### PR TITLE
[17.0][FIX] fieldservice_sale: Correctly compute template on FSM order creation

### DIFF
--- a/fieldservice_sale/models/sale_order.py
+++ b/fieldservice_sale/models/sale_order.py
@@ -77,6 +77,10 @@ class SaleOrder(models.Model):
         self.ensure_one()
         template_id = kwargs.get("template_id", False)
         template_ids = kwargs.get("template_ids", [template_id])
+        # If only 1 template_ids is given, use it as template_id
+        # As it's the only template to consider
+        if len(template_ids) == 1 and not template_id:
+            template_id = template_ids[0]
         templates = self.env["fsm.template"].search([("id", "in", template_ids)])
         note = ""
         hours = 0.0
@@ -120,6 +124,9 @@ class SaleOrder(models.Model):
                     so_id=self.id, template_ids=templates.ids
                 )
                 fsm_by_sale = self.env["fsm.order"].sudo().create(vals)
+                # Update the FSM Order based on the template
+                if len(templates.ids) == 1:
+                    fsm_by_sale._onchange_template_id()
                 new_fsm_orders |= fsm_by_sale
             new_fsm_sol.write({"fsm_order_id": fsm_by_sale.id})
 


### PR DESCRIPTION
Before this change, when using a single product with FSM tracking set to 'sale', the FSM order was not auto-completed with its template. Now the template is properly assigned during order creation.