### PR TITLE
[17.0][FIX] fieldservice: Use date_stop on calendar view

### DIFF
--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -461,6 +461,7 @@
             <calendar
                 string="FSM Orders"
                 date_start="scheduled_date_start"
+                date_stop="scheduled_date_end"
                 date_delay="scheduled_duration"
                 color="custom_color"
             >


### PR DESCRIPTION
Avoids fetching all service orders when opening the calendar view, which caused unnecessary queries and performance issues. Now only records within the selected time period are retrieved.

For example, viewing the calendar in week mode:

### Using the date_stop
it will only fetch the registers of the selected week:
<img width="671" height="124" alt="image" src="https://github.com/user-attachments/assets/168b1fc8-654e-44e8-aca0-1838145fe688" />

the domain used to fetch the records:

<img width="440" height="142" alt="image" src="https://github.com/user-attachments/assets/6c35016d-316d-4e6a-a0b5-74632d734eaa" />

### Not using date_stop
All service orders created before the last day shown in the calendar view are fetched, leading to excessive queries and degraded performance:
<img width="671" height="124" alt="image" src="https://github.com/user-attachments/assets/62a5ecd7-f0c8-4bcd-9dec-2ea2e5d1535b" />

the domain used to fetch the records:


<img width="410" height="80" alt="image" src="https://github.com/user-attachments/assets/03c84e8c-3db6-4193-9298-26bdb44bcf92" />