### PR TITLE
[18.0] [IMP] fieldservice: drop is_button field

### DIFF
--- a/fieldservice/models/fsm_order.py
+++ b/fieldservice/models/fsm_order.py
@@ -308,15 +308,13 @@ class FSMOrder(models.Model):
                 vals = self._calc_request_late(vals)
         return super().create(vals_list)
 
-    is_button = fields.Boolean(default=False)
-
     def write(self, vals):
-        if vals.get("stage_id", False) and vals.get("is_button", False):
-            vals["is_button"] = False
-        else:
-            stage_id = self.env["fsm.stage"].browse(vals.get("stage_id"))
-            if stage_id == self.env.ref("fieldservice.fsm_stage_completed"):
-                raise UserError(_("Cannot move to completed from Kanban"))
+        if (
+            not self.env.context.get("bypass_order_completed_stage")
+            and (stage_id := vals.get("stage_id"))
+            and stage_id == self.env.ref("fieldservice.fsm_stage_completed").id
+        ):
+            raise UserError(_("Cannot move to completed from Kanban"))
         self._calc_scheduled_dates(vals)
         res = super().write(vals)
         return res
@@ -380,10 +378,9 @@ class FSMOrder(models.Model):
             vals["scheduled_date_end"] = False
 
     def action_complete(self):
-        return self.write(
+        return self.with_context(bypass_order_completed_stage=True).write(
             {
                 "stage_id": self.env.ref("fieldservice.fsm_stage_completed").id,
-                "is_button": True,
             }
         )
 

--- a/fieldservice/tests/test_fsm_order.py
+++ b/fieldservice/tests/test_fsm_order.py
@@ -7,6 +7,7 @@ from odoo import fields
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
 
 
 class TestFSMOrder(TransactionCase):
@@ -37,6 +38,14 @@ class TestFSMOrder(TransactionCase):
         cls.tag1 = cls.env["fsm.tag"].create(
             {"name": "Test Tag1", "parent_id": cls.tag.id}
         )
+        cls.order = cls.env["fsm.order"].create(
+            {
+                "location_id": cls.test_location.id,
+                "date_start": fields.Datetime.today(),
+                "date_end": fields.Datetime.today() + timedelta(hours=10),
+                "request_early": fields.Datetime.today(),
+            }
+        )
 
     def test_fsm_order_default_stage(self):
         view_id = "fieldservice.fsm_order_form"
@@ -55,13 +64,12 @@ class TestFSMOrder(TransactionCase):
 
     def test_fsm_order_default_team(self):
         view_id = "fieldservice.fsm_order_form"
-        with self.assertRaises(ValidationError):
-            team_ids = self.env["fsm.team"].search(
-                [("company_id", "in", (self.env.user.company_id.id, False))],
-                order="sequence asc",
-            )
-            for team in team_ids:
-                team.unlink()
+        with mute_logger("odoo.models.unlink"):
+            self.order.unlink()
+            self.env["fsm.team"].search([]).unlink()
+        with self.assertRaisesRegex(
+            ValidationError, "You must create an FSM team first."
+        ):
             Form(self.Order, view=view_id)
 
     def test_fsm_order_create(self):
@@ -264,22 +272,21 @@ class TestFSMOrder(TransactionCase):
             )
         )
         self.assertTrue(data, "It should be able to read group")
-        self.Order.write(
-            {
-                "location_id": self.test_location.id,
-                "stage_id": self.stage1.id,
-                "is_button": True,
-            }
-        )
-        with self.assertRaises(UserError):
-            self.Order.write(
-                {
-                    "location_id": self.test_location.id,
-                    "stage_id": self.stage1.id,
-                }
-            )
         order.can_unlink()
         order.unlink()
+
+    def test_order_move_to_completed(self):
+        """Test move to completed
+
+        An order can't be moved to Completed directly from Kanban or Status bar.
+        Instead, it should go through the "Complete" button (action_complete).
+        """
+        # Can't move to completed directly
+        with self.assertRaisesRegex(UserError, "Cannot move to completed from Kanban"):
+            self.order.stage_id = self.stage1
+        # Instead, it should go through the "Complete" button (action_complete).
+        self.order.action_complete()
+        self.assertEqual(self.order.stage_id, self.stage1)
 
     def test_order_unlink(self):
         with self.assertRaises(ValidationError):

--- a/fieldservice/views/fsm_order.xml
+++ b/fieldservice/views/fsm_order.xml
@@ -6,7 +6,6 @@
         <field name="arch" type="xml">
             <form string="Order">
                 <header>
-                    <field name="is_button" invisible="1" />
                     <field name="team_id" invisible="1" />
                     <button
                         id="action_complete"


### PR DESCRIPTION
This field was only used to ensure an order can only be moved to a Completed stage through the "Complete" button (action_complete).

Instead, rely on a context flag to bypass the validation.