### PR TITLE
[18.0] [FIX] fieldservice_agreement: Equipments smartbutton label

### DIFF
--- a/fieldservice_agreement/views/agreement_view.xml
+++ b/fieldservice_agreement/views/agreement_view.xml
@@ -30,7 +30,7 @@
                     <field
                         name="equipment_count"
                         widget="statinfo"
-                        string="Service Orders"
+                        string="Equipments"
                     />
                 </button>
             </div>


### PR DESCRIPTION
Regression since the migration to 18.0:
- https://github.com/OCA/field-service/commit/1159b5d1dbd65893e83a1bc722f2a66af74be918

It was switched to a field with `statinfo` widget ✅ , but the label is wrong