### PR TITLE
[17.0] [IMP] fieldservice_recurring: optimize order generation logic

### DIFF
--- a/fieldservice_recurring/models/fsm_recurring.py
+++ b/fieldservice_recurring/models/fsm_recurring.py
@@ -219,15 +219,13 @@ class FSMRecurringOrder(models.Model):
         """
         orders = self.env["fsm.order"]
         for rec in self:
-            order_dates = []
-            for order in rec.fsm_order_ids:
-                if order.scheduled_date_start:
-                    order_dates.append(order.scheduled_date_start.date())
             max_orders = rec.max_orders if rec.max_orders > 0 else False
             order_count = rec.fsm_order_count
-            for date in rec._get_rruleset():
-                if date.date() in order_dates:
-                    continue
+            dates = list(rec._get_rruleset())
+            if order_count > 0:
+                # skip first date since an order already exists for that date
+                dates = dates[1:]
+            for date in dates:
                 if max_orders > order_count or not max_orders:
                     orders |= rec._create_order(date=date)
                     order_count += 1


### PR DESCRIPTION

I experienced an issue with the field service recurring cron task that generates new orders.  A memory limit was reached and the task would fail to execute in some databases that have some fsm_recurring records with a high number of linked fsm_order records

It would always hang in this block of code

> 
>             for order in rec.fsm_order_ids:
>                 if order.scheduled_date_start:
>                     order_dates.append(order.scheduled_date_start.date())

The `order_dates` list was used to prevent creating new orders on a date which there already exists an order.  However, we do not need to even consider all these dates in the past

This change removes the `order_dates` list.  Instead, the first element of the rruleset is skipped if an order already exists in the recurring.  This date is the same as the 'dtstart' parameter which is derived from the last scheduled order
