### PR TITLE
[17.0] [IMP] fieldservice_vehicle: enable creation in batch for extended fsm.order model

### DIFF
--- a/fieldservice_vehicle/models/fsm_order.py
+++ b/fieldservice_vehicle/models/fsm_order.py
@@ -14,11 +14,13 @@ class FSMOrder(models.Model):
         "fsm.vehicle", string="Vehicle", default=_get_default_vehicle
     )
 
-    @api.model
-    def create(self, vals):
-        res = super().create(vals)
-        if not vals.get("vehicle_id") and vals.get("person_id"):
-            self._onchange_person_id()
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        for vals in vals_list:
+            if not vals.get("vehicle_id") and vals.get("person_id"):
+                for record in res:
+                    record._onchange_person_id()
         return res
 
     @api.onchange("person_id")

--- a/fieldservice_vehicle/models/fsm_vehicle.py
+++ b/fieldservice_vehicle/models/fsm_vehicle.py
@@ -7,7 +7,7 @@ class FSMVehicle(models.Model):
     _name = "fsm.vehicle"
     _description = "Field Service Vehicle"
 
-    name = fields.Char(required="True")
+    name = fields.Char(required=True)
     person_id = fields.Many2one("fsm.person", string="Assigned Driver")
 
     _sql_constraints = [


### PR DESCRIPTION
1. This first commit of this PR fix this warning:

`WARNING ? odoo.api.create: The model odoo.addons.fieldservice_vehicle.models.fsm_order is not overriding the create method in batch
`

2. The second commmit fixes the following warning:

```
WARNING ? py.warnings: /opt/odoo/custom/src/odoo/odoo/fields.py:536: UserWarning: Property fsm.vehicle.name.required should be a boolean (True).
  File "/usr/local/bin/click-odoo-copydb", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1462, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1383, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.10/site-packages/click_odoo/env_options.py", line 215, in _invoke
    return self.org_invoke(ctx)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1246, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 814, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/click_odoo_contrib/copydb.py", line 130, in main
    reset_config_parameters(dest)
  File "/usr/local/lib/python3.10/site-packages/click_odoo_contrib/_dbutils.py", line 104, in reset_config_parameters
    with OdooEnvironment(dbname) as env:
  File "/usr/local/lib/python3.10/contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "/usr/local/lib/python3.10/site-packages/click_odoo/env.py", line 16, in OdooEnvironment
    registry = odoo.modules.registry.Registry(database)
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 89, in __new__
    return cls.new(db_name)
  File "<decorator-gen-16>", line 2, in new
  File "/opt/odoo/custom/src/odoo/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 110, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 507, in load_modules
    registry.setup_models(cr)
  File "<decorator-gen-19>", line 2, in setup_models
  File "/opt/odoo/custom/src/odoo/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 319, in setup_models
    model._setup_fields()
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3420, in _setup_fields
    field.setup(self)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 536, in setup
    warnings.warn(f'Property {self}.required should be a boolean ({self.required}).')
```

@BinhexTeam T18741