### PR TITLE
[17.0] [IMP] fieldservice_account_analytic: use python contrains instead of validation at creation for analytic lines

### DIFF
--- a/fieldservice_account_analytic/models/analytic_account.py
+++ b/fieldservice_account_analytic/models/analytic_account.py
@@ -11,17 +11,21 @@ class AccountAnalyticLine(models.Model):
     fsm_order_id = fields.Many2one("fsm.order", string="FSM Order")
     product_id = fields.Many2one("product.product", string="Time Type")
 
-    @api.model
-    def create(self, vals):
-        order = self.env["fsm.order"].browse(vals.get("fsm_order_id"))
-        if order:
-            if order.location_id.analytic_account_id:
-                vals["account_id"] = order.location_id.analytic_account_id.id
-            else:
+    @api.constrains("fsm_order_id")
+    def _check_fsm_order_id(self):
+        for line in self:
+            if (
+                line.fsm_order_id
+                and not line.fsm_order_id.location_id.analytic_account_id
+            ):
                 raise ValidationError(
-                    _("No analytic account set " "on the order's Location.")
+                    _(
+                        "No analytic account set on the order's Location "
+                        "%(location_name)s. Please set an analytic account on the "
+                        "Location before creating an analytic line for this order.",
+                        location_name=line.fsm_order_id.location_id.name,
+                    )
                 )
-        return super().create(vals)
 
     @api.onchange("product_id")
     def onchange_product_id(self):


### PR DESCRIPTION
I found this issue after seeing the following warning:

`WARNING ? odoo.api.create: The model odoo.addons.fieldservice_account_analytic.models.analytic_account is not overriding the create method in batch`

When refactoring to use `@api.model_create_multi`, it became clear that a Python constraint is the more appropriate solution.

@BinhexTeam T18741
