### PR TITLE
[IMP] fieldservice_geoengine: Using mock data for OpenStreetMap

### DIFF
--- a/fieldservice_geoengine/tests/test_fsm_location.py
+++ b/fieldservice_geoengine/tests/test_fsm_location.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2023 - TODAY Pytech SRL
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from unittest.mock import MagicMock, patch
+
 from odoo import fields
 from odoo.tests.common import TransactionCase
 
@@ -30,7 +32,19 @@ class TestFsmLocation(TransactionCase):
             }
         )
 
-    def test_fsm_location_creation(self):
+    @patch("requests.get")
+    def test_fsm_location_creation(self, requests_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json = MagicMock(
+            return_value=[
+                {
+                    "lat": "50.629980",
+                    "lon": "4.863370",
+                }
+            ]
+        )
+        requests_get.return_value = mock_response
         test_partner = self.env["res.partner"].create(
             {
                 "name": "Test partner",


### PR DESCRIPTION
> The other test failure is due to openstreetmaps rate limiting the tests
> 
> https://github.com/OCA/field-service/actions/runs/22137338801/job/63992330395?pr=1516#step:8:229
> 
> A similar fix has been proposted in the geospatial repository: https://github.com/OCA/geospatial/pull/409/changes/d125f93d8ab3c39a42efb5be9d9146f13d13d9f9
> 
> We could copy it here as well

_Originally posted by @HekkiMelody in https://github.com/OCA/field-service/issues/1516#issuecomment-3944795458_
            
I cherry-picked that commit (with same author @anusriNPS) and works like a charm, please have a look.
Thanks!