### PR TITLE
[18.0][FIX] fieldservice: Create fsm_person directly in FSM form.

### DIFF
--- a/fieldservice/views/fsm_person.xml
+++ b/fieldservice/views/fsm_person.xml
@@ -100,6 +100,7 @@
                             <field
                                 name="partner_id"
                                 groups="base.group_no_one"
+                                required="0"
                                 readonly="1"
                             />
                             <field


### PR DESCRIPTION
Fixes #1407
Currently, the only way to create a FSM Person is using a server action in the Contacts app. Creation inside the Field Service app is broken because in the fsm_person form, partner_id is required AND readonly.