### PR TITLE
[IMP] fieldservice_crm: add Create FSM Order button to CRM lead header

### DIFF
--- a/fieldservice_crm/README.rst
+++ b/fieldservice_crm/README.rst
@@ -57,8 +57,9 @@ Usage
 -  User must have Field Service User permissions
 -  Go to CRM app
 -  Create a new Opportunity
--  Click the FS Orders Smart Button
--  Create a Field Service Order
+-  Click the **Create FSM Order** button in the header to open a
+   pre-filled order form, or click the **FS Orders** smart button to
+   manage existing orders
 
 Known issues / Roadmap
 ======================

--- a/fieldservice_crm/models/crm_lead.py
+++ b/fieldservice_crm/models/crm_lead.py
@@ -18,3 +18,18 @@ class Lead(models.Model):
     def _compute_fsm_order_count(self):
         for rec in self:
             rec.fsm_order_count = len(rec.fsm_order_ids)
+
+    def action_create_fsm_order(self):
+        self.ensure_one()
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "fieldservice.action_fsm_operation_order"
+        )
+        action["context"] = {
+            "default_opportunity_id": self.id,
+            "default_location_id": self.fsm_location_id.id,
+            "default_description": self.description,
+            "default_priority": self.priority,
+        }
+        view = self.env.ref("fieldservice.fsm_order_form", raise_if_not_found=False)
+        action["views"] = [(view and view.id or False, "form")]
+        return action

--- a/fieldservice_crm/readme/USAGE.md
+++ b/fieldservice_crm/readme/USAGE.md
@@ -1,5 +1,5 @@
 - User must have Field Service User permissions
 - Go to CRM app
 - Create a new Opportunity
-- Click the FS Orders Smart Button
-- Create a Field Service Order
+- Click the **Create FSM Order** button in the header to open a pre-filled order form,
+  or click the **FS Orders** smart button to manage existing orders

--- a/fieldservice_crm/static/description/index.html
+++ b/fieldservice_crm/static/description/index.html
@@ -407,8 +407,9 @@ install GeoEngine.</p>
 <li>User must have Field Service User permissions</li>
 <li>Go to CRM app</li>
 <li>Create a new Opportunity</li>
-<li>Click the FS Orders Smart Button</li>
-<li>Create a Field Service Order</li>
+<li>Click the <strong>Create FSM Order</strong> button in the header to open a
+pre-filled order form, or click the <strong>FS Orders</strong> smart button to
+manage existing orders</li>
 </ul>
 </div>
 <div class="section" id="known-issues-roadmap">

--- a/fieldservice_crm/tests/test_fsm_crm.py
+++ b/fieldservice_crm/tests/test_fsm_crm.py
@@ -28,3 +28,26 @@ class TestFieldserviceCrm(common.TransactionCase):
 
         location_1._compute_opportunity_count()
         self.assertEqual(location_1.opportunity_count, 1)
+
+    def test_action_create_fsm_order(self):
+        location = self.env["fsm.location"].create(
+            {
+                "name": "Test Location",
+                "owner_id": self.env["res.partner"].create({"name": "Test Owner"}).id,
+            }
+        )
+        lead = self.env["crm.lead"].create(
+            {
+                "name": "Test Opportunity",
+                "type": "opportunity",
+                "fsm_location_id": location.id,
+                "description": "<p>Test description</p>",
+                "priority": "1",
+            }
+        )
+        action = lead.action_create_fsm_order()
+        ctx = action.get("context", {})
+        self.assertEqual(ctx.get("default_opportunity_id"), lead.id)
+        self.assertEqual(ctx.get("default_location_id"), location.id)
+        self.assertEqual(ctx.get("default_description"), "<p>Test description</p>")
+        self.assertEqual(ctx.get("default_priority"), "1")

--- a/fieldservice_crm/views/crm_lead.xml
+++ b/fieldservice_crm/views/crm_lead.xml
@@ -5,8 +5,18 @@
         <field name="name">fieldservice.crm.form</field>
         <field name="model">crm.lead</field>
         <field name="inherit_id" ref="crm.crm_lead_view_form" />
-        <field eval="1" name="priority" />
+        <field eval="20" name="priority" />
         <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_set_won_rainbowman']" position="before">
+                <button
+                    name="action_create_fsm_order"
+                    string="Create FSM Order"
+                    type="object"
+                    class="oe_highlight"
+                    groups="fieldservice.group_fsm_user"
+                    invisible="type == 'lead'"
+                />
+            </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button
                     class="oe_stat_button o_res_partner_tip_opp"


### PR DESCRIPTION
Add action_create_fsm_order() method on crm.lead that opens the FSM order form pre-filled with opportunity_id, location_id, description, and priority from the CRM lead. Button placed in header as oe_highlight before the Won button, following the fieldservice_project pattern.

<img width="1272" height="722" alt="image" src="https://github.com/user-attachments/assets/4620047b-36b6-4bcb-8c33-be0f4ac4c010" />


@BinhexTeam T18387