### PR TITLE
[16.0][IMP] fieldservice_geoengine: Updated display information for legends

### DIFF
--- a/fieldservice_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
+++ b/fieldservice_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
@@ -114,7 +114,9 @@ patch(GeoengineRenderer.prototype, "geoengine_renderer_view_patch", {
                         16
                     );
                 }
-                data.push(record);
+                if (record.data[vector.geo_field_id[1]] !== false) {
+                    data.push(record);
+                }
             }
             this.styleVectorLayerAndLegend(vector, data, layer);
             this.addSourceToLayer(data, vector, layer);


### PR DESCRIPTION
   Based on [#456](https://github.com/OCA/geospatial/pull/456) base_geoengine PR, updating patched functions to display legend information only for records with coordinate details.