### PR TITLE
[18.0][FIX] fieldservice_stage_server_action

### DIFF
--- a/fieldservice_stage_server_action/models/fsm_order.py
+++ b/fieldservice_stage_server_action/models/fsm_order.py
@@ -27,5 +27,6 @@ class FSMOrder(models.Model):
             ctx = {
                 "active_model": self._name,
                 "active_id": order.id,
+                "active_ids": [order.id],
             }
             action_id.with_context(**ctx).run()

--- a/fieldservice_stage_server_action/tests/test_fsm_order_run_action.py
+++ b/fieldservice_stage_server_action/tests/test_fsm_order_run_action.py
@@ -38,3 +38,34 @@ class TestFSMOrderRunAction(TransactionCase):
         tag = capture.records
         self.assertEqual(1, len(tag))
         self.assertEqual("New test tag", tag.name)
+
+    def test_stage_server_action_overrides_stale_active_ids(self):
+        action = self.env["ir.actions.server"].create(
+            {
+                "name": "Check active FSM order",
+                "model_id": self.env["ir.model"]._get_id("fsm.order"),
+                "state": "code",
+                "code": "record.message_post(body='Stage action executed')",
+            }
+        )
+        self.stage2.action_id = action
+        order = self.Order.create(
+            {
+                "location_id": self.test_location.id,
+                "stage_id": self.stage1.id,
+            }
+        )
+        order.with_context(
+            active_model="fsm.order",
+            active_id=order.id,
+            active_ids=[999999],
+        ).write({"stage_id": self.stage2.id})
+        self.assertTrue(
+            self.env["mail.message"].search(
+                [
+                    ("model", "=", "fsm.order"),
+                    ("res_id", "=", order.id),
+                    ("body", "ilike", "Stage action executed"),
+                ]
+            )
+        )


### PR DESCRIPTION
@BinhexTeam

T23058

Fixes stage server actions using stale `active_ids` from the previous context.

`ir.actions.server.run()` prioritizes `active_ids` over `active_id`. Since the current code only sets `active_model` and `active_id`, an inherited `active_ids` value can make the action run on the wrong record, causing `MissingError`.

This fix sets `active_ids` to the current FSM Order ID so `active_model`, `active_id`, and `active_ids` stay consistent.


### Steps to reproduce

1. Configure a server action on an FSM stage (Field service -> Configuration -> Stages).
   
<img width="3024" height="1654" alt="image" src="https://github.com/user-attachments/assets/e9754838-fb05-46c3-b158-bbd19f20077d" />

3. Open a Project Task.
4. Click **Create FSM Order** from the task.
     
<img width="3024" height="1654" alt="image" src="https://github.com/user-attachments/assets/6a6a7b02-30c2-4c8f-af9a-5a9139c00811" />

5. Save the new FSM Order.
6. Move the FSM Order to the stage configured in step 1.

If the task context is still present in `active_ids`, Odoo tries to run the server action on `fsm.order(<project.task id>)` and raises:
```text
Missing Record

Record does not exist or has been deleted.
(Record: fsm.order(...), User: ...)
