### PR TITLE
[FIX] fieldservice fsm_person_form: in debug mode it's not possible to save a person

### DIFF
--- a/fieldservice/views/fsm_person.xml
+++ b/fieldservice/views/fsm_person.xml
@@ -101,6 +101,7 @@
                                 name="partner_id"
                                 groups="base.group_no_one"
                                 readonly="1"
+                                required="0"
                             />
                             <field
                                 name="category_ids"


### PR DESCRIPTION


due to the mandatory and non-editable partner_id field