### PR TITLE
[16.0] [FIX] fieldservice_sale: fall back to partner's primary service location

### DIFF
--- a/fieldservice_sale/models/sale_order.py
+++ b/fieldservice_sale/models/sale_order.py
@@ -39,12 +39,13 @@ class SaleOrder(models.Model):
             sale.fsm_order_ids = fsm
             sale.fsm_order_count = len(sale.fsm_order_ids)
 
-    @api.depends("partner_id", "partner_shipping_id")
+    @api.depends("partner_id", "partner_shipping_id", "partner_id.service_location_id")
     def _compute_fsm_location_id(self):
         """
         Autofill the Sale Order's FS location with the partner_id,
         the partner_shipping_id or the partner_id.commercial_partner_id if
-        they are FS locations.
+        they are FS locations. As a last resort, fall back to the customer's
+        primary service location (res.partner.service_location_id).
         """
         for so in self:
             if so.partner_id.fsm_location:
@@ -57,7 +58,8 @@ class SaleOrder(models.Model):
                     ("partner_id", "=", so.partner_shipping_id.id),
                     ("partner_id", "=", so.partner_id.commercial_partner_id.id),
                 ]
-            so.fsm_location_id = self.env["fsm.location"].search(domain, limit=1)
+            location = self.env["fsm.location"].search(domain, limit=1)
+            so.fsm_location_id = location or so.partner_id.service_location_id
 
     def _prepare_line_fsm_values(self, line):
         """

--- a/fieldservice_sale/tests/test_fsm_sale_autofill_location.py
+++ b/fieldservice_sale/tests/test_fsm_sale_autofill_location.py
@@ -96,3 +96,32 @@ class FSMSale(TransactionCase):
             so_form.partner_id = self.partner
         so = so_form.save()
         self.assertEqual(so.fsm_location_id, self.location1)
+
+    def test_04_autofill_so_fsm_location_from_service_location(self):
+        """Check location autofill falls back to service_location_id
+
+        Neither the SO partner, its shipping partner nor its commercial
+        partner backs an FSM location, but the partner's primary service
+        location points at location2 => expect location2.
+        """
+        self.partner.fsm_location = False
+        self.partner.service_location_id = self.location2
+        with Form(self.env["sale.order"]) as so_form:
+            so_form.partner_id = self.partner
+        so = so_form.save()
+        self.assertEqual(so.fsm_location_id, self.location2)
+
+    def test_05_autofill_so_fsm_location_service_location_is_fallback(self):
+        """Check the service_location_id is only a last resort
+
+        A location explicitly linked to the partner takes precedence over the
+        partner's primary service location: location1 backs the partner and
+        service_location_id points at location2 => expect location1.
+        """
+        self.partner.fsm_location = False
+        self.location1.partner_id = self.partner
+        self.partner.service_location_id = self.location2
+        with Form(self.env["sale.order"]) as so_form:
+            so_form.partner_id = self.partner
+        so = so_form.save()
+        self.assertEqual(so.fsm_location_id, self.location1)


### PR DESCRIPTION
  When autofilling a Sale Order's Service Location, the location was only
  resolved by matching an fsm.location whose related partner_id is the SO
  customer, its shipping partner or its commercial partner. A customer that
  is an ordinary contact (not itself a location) was left without a location,
  even when its res.partner.service_location_id explicitly pointed at one.

  Add service_location_id as a last-resort fallback in
  _compute_fsm_location_id: the existing partner -> location matching still
  takes precedence, and the customer's primary service location is used only
  when no other match is found. service_location_id is added to the field's
  depends so the SO location recomputes when it changes.