### PR TITLE
[16.0] [IMP] fieldservice_isp_account: show bill_to field only when installed

### DIFF
--- a/fieldservice_account_analytic/views/fsm_order.xml
+++ b/fieldservice_account_analytic/views/fsm_order.xml
@@ -4,17 +4,6 @@
         <field name="model">fsm.order</field>
         <field name="inherit_id" ref="fieldservice.fsm_order_form" />
         <field name="arch" type="xml">
-            <notebook position="inside">
-                <page name="accounting" string="Accounting">
-                    <group name="bill_to">
-                        <field
-                            name="bill_to"
-                            widget="radio"
-                            options="{'horizontal': true}"
-                        />
-                    </group>
-                </page>
-            </notebook>
             <field name="region_id" position="after">
                 <field name="customer_id" context="{'location_id': location_id}" />
             </field>

--- a/fieldservice_isp_account/views/fsm_order.xml
+++ b/fieldservice_isp_account/views/fsm_order.xml
@@ -7,6 +7,17 @@
             ref="fieldservice_account_analytic.fsm_order_form_analytic"
         />
         <field name="arch" type="xml">
+            <notebook position="inside">
+                <page name="accounting" string="Accounting">
+                    <group name="bill_to">
+                        <field
+                            name="bill_to"
+                            widget="radio"
+                            options="{'horizontal': true}"
+                        />
+                    </group>
+                </page>
+            </notebook>
             <group name="bill_to" position="before">
                 <header>
                     <button


### PR DESCRIPTION
  The bill_to field is defined in fieldservice_account_analytic but its
  value is only consumed by fieldservice_isp_account (account_prepare_invoice).
  With only fieldservice_account_analytic installed, the user was shown a
  required "Bill Location / Bill Contact" radio that had no effect.

  Move the "Accounting" page and the bill_to widget from the
  fieldservice_account_analytic form view into the fieldservice_isp_account
  form view, so the field is only displayed when the module that actually
  uses it is installed.

  The field definition stays on the model in fieldservice_account_analytic,
  so the database column is preserved and no migration is required.