### PR TITLE
[16.0][FIX] fieldservice_isp_flow: fix search view inheritance with translations

### DIFF
--- a/fieldservice_isp_flow/views/fsm_order.xml
+++ b/fieldservice_isp_flow/views/fsm_order.xml
@@ -93,15 +93,13 @@
         <field name="model">fsm.order</field>
         <field name="inherit_id" ref="fieldservice.fsm_order_search_view" />
         <field name="arch" type="xml">
-            <search string="Orders">
-                <filter name="order_today" position="before">
-                    <filter
-                        string="Past Due Orders"
-                        domain="[('stage_id.name', 'not in', ['Started', 'Completed', 'Cancelled']), ('scheduled_date_start', '&lt;', current_date)]"
-                        name="past_due"
-                    />
-                </filter>
-            </search>
+            <xpath expr="//filter[@name='order_today']" position="before">
+                <filter
+                    string="Past Due Orders"
+                    domain="[('stage_id.name', 'not in', ['Started', 'Completed', 'Cancelled']), ('scheduled_date_start', '&lt;', current_date)]"
+                    name="past_due"
+                />
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
## Summary

- Replace string-based search view inheritance (`<search string="Orders">`) with an XPath targeting `//filter[@name='order_today']`
- Ensures `fieldservice_isp_flow` works when parent view labels are translated (e.g. French)

Fixes https://github.com/OCA/field-service/issues/1525

## Test plan

- [x] Install `fieldservice` and load French translations
- [x] Install `fieldservice_isp_flow`
- [x] Open Field Service → Operations → All Orders
- [x] Confirm the search view loads without error and the "Past Due Orders" filter is present


Made with [Cursor](https://cursor.com)