### PR TITLE
[19.0][FIX] fieldservice: point timeline setting at fieldservice_timeline

### DIFF
--- a/fieldservice/models/res_config_settings.py
+++ b/fieldservice/models/res_config_settings.py
@@ -70,7 +70,7 @@ class ResConfigSettings(models.TransientModel):
     module_fieldservice_stock = fields.Boolean(string="Use Odoo Logistics")
     module_fieldservice_vehicle = fields.Boolean(string="Manage Vehicles")
     module_fieldservice_substatus = fields.Boolean(string="Manage Sub-Statuses")
-    module_fieldservice_web_timeline_view = fields.Boolean(
+    module_fieldservice_timeline = fields.Boolean(
         string="Allow Field Service Web Timeline View"
     )
 

--- a/fieldservice/views/res_config_settings.xml
+++ b/fieldservice/views/res_config_settings.xml
@@ -190,8 +190,11 @@
                         >
                             <field name="module_fieldservice_size" />
                         </setting>
-                        <setting string="Allow Field Service Web Timeline View">
-                            <field name="module_fieldservice_web_timeline_view" />
+                        <setting
+                            string="Allow Field Service Web Timeline View"
+                            help="Display Field Service orders in a timeline view"
+                        >
+                            <field name="module_fieldservice_timeline" />
                         </setting>
                     </block>
 


### PR DESCRIPTION
## Summary
- Rename the Settings install toggle from `module_fieldservice_web_timeline_view` to `module_fieldservice_timeline` so it matches the actual addon technical name (renamed in 13.0).
- Enabling **Allow Field Service Web Timeline View** can now install `fieldservice_timeline` when that module is available in the addons path.

## Test plan
- [x] Upgrade `fieldservice`
- [x] Open Settings → Field Service and confirm the Web Timeline View checkbox is still present
- [ ] With `fieldservice_timeline` in the addons path and Apps list updated, enable the checkbox and save — module installs without "modules are not available: fieldservice_web_timeline_view"
- [ ] Without `fieldservice_timeline` available, the checkbox still refers to the correct module name