### PR TITLE
[19.0][FIX] fieldservice_kanban_info: use frozen time in schedule format tests

### DIFF
--- a/fieldservice_kanban_info/tests/test_fieldservice_kanban_info.py
+++ b/fieldservice_kanban_info/tests/test_fieldservice_kanban_info.py
@@ -59,7 +59,9 @@ class TestFieldServiceKanbanInfo(FSMCommon):
             "fieldservice.schedule_time_range_format", "date_and_time"
         )
 
-        order = self._create_order(self.now, self.now + relativedelta(hours=2))
+        # Use Datetime.now() inside freeze_time; setUpClass.now is wall-clock.
+        now = fields.Datetime.now()
+        order = self._create_order(now, now + relativedelta(hours=2))
         self.assertRegex(
             order.schedule_time_range,
             r"\d{2}/\d{2}/\d{4} \d{2}:\d{2} (AM|PM) - \d{2}:\d{2} (AM|PM)",
@@ -77,7 +79,9 @@ class TestFieldServiceKanbanInfo(FSMCommon):
             "fieldservice.schedule_time_range_format", "date_and_time"
         )
 
-        order = self._create_order(self.now, self.now + relativedelta(hours=2))
+        # Use Datetime.now() inside freeze_time; setUpClass.now is wall-clock.
+        now = fields.Datetime.now()
+        order = self._create_order(now, now + relativedelta(hours=2))
         self.assertRegex(
             order.schedule_time_range, r"\d{2}/\d{2}/\d{4} \d{2}:\d{2} - \d{2}:\d{2}"
         )


### PR DESCRIPTION
## Summary
- `TestFieldServiceKanbanInfo` stored `cls.now` in `setUpClass` (wall clock), then reused it inside `@freeze_time` tests.
- When CI ran after ~22:00 UTC, `now + 2 hours` crossed midnight and the same-day date/time regex failed.
- Use `fields.Datetime.now()` inside the frozen tests so freezegun applies.

Unblocks migration PRs that currently fail on unrelated `fieldservice_kanban_info` tests (e.g. #1585).

## Test plan
- [x] CI `test with Odoo` / `test with OCB` green
- [x] Confirm `test_schedule_time_range_us_format` and `test_schedule_time_range_eu_format` pass regardless of wall-clock hour