### PR TITLE
[19.0][FIX] fieldservice: restore partner delegation on location/worker create

### DIFF
--- a/fieldservice/README.rst
+++ b/fieldservice/README.rst
@@ -158,6 +158,15 @@ performed.
 1. Go to *Field Service > Master Data > Locations*
 2. Create a location
 
+You can also convert an existing contact:
+
+1. Open the contact form
+2. Go to the *Field Service* tab
+3. Click *Convert to FS Location*
+
+Or create a child contact with type *Location* under a customer; a
+related Field Service location is created automatically.
+
 Add Field Service Workers
 -------------------------
 
@@ -166,6 +175,12 @@ These workers may be subcontractors or a company's own employees.
 
 1. Go to *Field Service > Master Data > Workers*
 2. Create a worker
+
+You can also convert an existing contact:
+
+1. Open the contact form
+2. Go to the *Field Service* tab
+3. Click *Convert to FS Worker*
 
 Process Orders
 --------------

--- a/fieldservice/models/fsm_location.py
+++ b/fieldservice/models/fsm_location.py
@@ -92,10 +92,37 @@ class FSMLocation(models.Model):
     )
 
     @api.model_create_multi
-    def create(self, vals):
-        res = super().create(vals)
-        res.write({"fsm_location": True})
-        return res
+    def create(self, vals_list):
+        auto_partner_indexes = []
+        root_indexes = []
+        for index, vals in enumerate(vals_list):
+            # By default, create inherited partner as typed child of the location owner.
+            vals.update({"fsm_location": True, "type": "fsm_location"})
+            if not vals.get("partner_id"):  # Don't change parent of existing partners.
+                auto_partner_indexes.append(index)
+                if not vals.get("owner_id"):
+                    if vals.get("parent_id"):
+                        parent = self.browse(vals["parent_id"])
+                        vals["owner_id"] = parent.owner_id.id
+                    else:
+                        root_indexes.append(index)
+                        vals["owner_id"] = self.env.company.partner_id.id
+                # Cannot set partner parent via vals["parent_id"]: that field is the
+                # location hierarchy on fsm.location (18.0+), not res.partner.parent_id.
+        locations = super(
+            FSMLocation, self.with_context(creating_fsm_location=True)
+        ).create(vals_list)
+        for index in root_indexes:
+            location = locations[index]
+            location.write({"owner_id": location.partner_id.id})
+            location.partner_id.parent_id = False
+        for index in auto_partner_indexes:
+            if index in root_indexes:
+                continue
+            location = locations[index]
+            if location.partner_id.parent_id != location.owner_id:
+                location.partner_id.parent_id = location.owner_id
+        return locations
 
     @api.depends("partner_id.name", "parent_id.complete_name", "ref")
     def _compute_complete_name(self):

--- a/fieldservice/models/fsm_person.py
+++ b/fieldservice/models/fsm_person.py
@@ -95,4 +95,6 @@ class FSMPerson(models.Model):
     def create(self, vals_list):
         for vals in vals_list:
             vals.update({"fsm_person": True})
-        return super().create(vals_list)
+        return super(FSMPerson, self.with_context(creating_fsm_person=True)).create(
+            vals_list
+        )

--- a/fieldservice/models/res_partner.py
+++ b/fieldservice/models/res_partner.py
@@ -52,7 +52,17 @@ class ResPartner(models.Model):
                 action["res_id"] = owned_location_ids.ids[0]
             return action
 
+    def action_fsm_convert_to_location(self):
+        self.ensure_one()
+        self.env["fsm.wizard"].action_convert_location(self)
+
+    def action_fsm_convert_to_person(self):
+        self.ensure_one()
+        self.env["fsm.wizard"].action_convert_person(self)
+
     def _create_missing_fsm_location(self):
+        if self.env.context.get("creating_fsm_location"):
+            return
         for rec in self:
             if rec.type != "fsm_location":
                 continue

--- a/fieldservice/readme/USAGE.md
+++ b/fieldservice/readme/USAGE.md
@@ -8,6 +8,15 @@ performed.
 1.  Go to *Field Service \> Master Data \> Locations*
 2.  Create a location
 
+You can also convert an existing contact:
+
+1.  Open the contact form
+2.  Go to the *Field Service* tab
+3.  Click *Convert to FS Location*
+
+Or create a child contact with type *Location* under a customer; a
+related Field Service location is created automatically.
+
 ## Add Field Service Workers
 
 Workers are the people responsible for performing a field service order.
@@ -15,6 +24,12 @@ These workers may be subcontractors or a company's own employees.
 
 1.  Go to *Field Service \> Master Data \> Workers*
 2.  Create a worker
+
+You can also convert an existing contact:
+
+1.  Open the contact form
+2.  Go to the *Field Service* tab
+3.  Click *Convert to FS Worker*
 
 ## Process Orders
 

--- a/fieldservice/static/description/index.html
+++ b/fieldservice/static/description/index.html
@@ -526,6 +526,14 @@ performed.</p>
 <li>Go to <em>Field Service &gt; Master Data &gt; Locations</em></li>
 <li>Create a location</li>
 </ol>
+<p>You can also convert an existing contact:</p>
+<ol class="arabic simple">
+<li>Open the contact form</li>
+<li>Go to the <em>Field Service</em> tab</li>
+<li>Click <em>Convert to FS Location</em></li>
+</ol>
+<p>Or create a child contact with type <em>Location</em> under a customer; a
+related Field Service location is created automatically.</p>
 </div>
 <div class="section" id="add-field-service-workers">
 <h3><a class="toc-backref" href="#toc-entry-13">Add Field Service Workers</a></h3>
@@ -534,6 +542,12 @@ These workers may be subcontractors or a company’s own employees.</p>
 <ol class="arabic simple">
 <li>Go to <em>Field Service &gt; Master Data &gt; Workers</em></li>
 <li>Create a worker</li>
+</ol>
+<p>You can also convert an existing contact:</p>
+<ol class="arabic simple">
+<li>Open the contact form</li>
+<li>Go to the <em>Field Service</em> tab</li>
+<li>Click <em>Convert to FS Worker</em></li>
 </ol>
 </div>
 <div class="section" id="process-orders">

--- a/fieldservice/tests/test_fsm_location.py
+++ b/fieldservice/tests/test_fsm_location.py
@@ -45,6 +45,14 @@ class FSMLocation(FSMCommon):
         ]:
             self.assertEqual(location[x], self.test_location[x])
 
+        # Check partner defaults.
+        self.assertTrue(location.fsm_location)
+        self.assertFalse(location.fsm_person)
+        self.assertFalse(location.is_company)
+        self.assertEqual(location.partner_id.parent_id, self.test_loc_partner)
+        self.assertNotEqual(location.partner_id, self.test_loc_partner)
+        self.assertEqual(location.type, "fsm_location")
+
         # Test initial stage
         self.assertEqual(location.stage_id, self.location_stage_1)
         # Test change state
@@ -284,3 +292,66 @@ class FSMLocation(FSMCommon):
                 Domain("active", "=", False) & Domain("id", "in", children_loc.ids)
             )
         )
+
+    def test_create_root_fsm_location(self):
+        """Root locations can be created without an existing partner."""
+        location = self.Location.create({"name": "Root Location"})
+        self.assertTrue(location.fsm_location)
+        self.assertEqual(location.type, "fsm_location")
+        self.assertEqual(location.owner_id, location.partner_id)
+        self.assertFalse(location.partner_id.parent_id)
+
+    def test_create_root_fsm_location_from_form(self):
+        """Root locations can be saved from the UI without owner or partner."""
+        with Form(self.Location, view="fieldservice.fsm_location_form_view") as f:
+            f.name = "Root Location From Form"
+        location = f.save()
+        self.assertEqual(location.owner_id, location.partner_id)
+
+    def test_child_partner_location_gets_parent_fsm_location(self):
+        """Child location partners inherit the parent contact FSM location."""
+        self.env["fsm.wizard"].action_convert_location(self.test_partner)
+        parent_location = self.test_partner.fsm_location_ids[:1]
+        child_loc = self.env["res.partner"].create(
+            {
+                "parent_id": self.test_partner.id,
+                "name": "Child Location",
+                "type": "fsm_location",
+            }
+        )
+        child_fsm_location = child_loc.fsm_location_ids[:1]
+        self.assertEqual(child_fsm_location.parent_id, parent_location)
+        self.assertEqual(child_fsm_location.owner_id, self.test_partner)
+
+    def test_create_sublocation_inherits_owner_from_parent(self):
+        """Sub-locations without owner inherit it from the parent location."""
+        location = self.Location.create(
+            {
+                "name": "Sub Without Owner",
+                "parent_id": self.test_location.id,
+            }
+        )
+        self.assertEqual(location.owner_id, self.test_location.owner_id)
+        self.assertEqual(location.partner_id.parent_id, self.test_location.owner_id)
+
+    def test_create_sublocation_from_form(self):
+        """Sub-locations created from the form inherit owner and partner parent."""
+        with Form(self.Location, view="fieldservice.fsm_location_form_view") as f:
+            f.name = "Child From Form"
+            f.parent_id = self.test_location
+        location = f.save()
+        self.assertEqual(location.owner_id, self.test_location.owner_id)
+        self.assertEqual(location.partner_id.parent_id, self.test_location.owner_id)
+
+    def test_create_location_with_existing_partner(self):
+        """Creating with an existing partner must not overwrite partner parent."""
+        partner = self.env["res.partner"].create({"name": "Existing Loc Partner"})
+        location = self.Location.create(
+            {
+                "name": "Existing Partner Location",
+                "partner_id": partner.id,
+                "owner_id": partner.id,
+            }
+        )
+        self.assertEqual(location.partner_id, partner)
+        self.assertFalse(location.partner_id.parent_id)

--- a/fieldservice/tests/test_fsm_order.py
+++ b/fieldservice/tests/test_fsm_order.py
@@ -4,7 +4,7 @@
 from datetime import timedelta
 from unittest.mock import patch
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
 from odoo.tests import Form
@@ -194,9 +194,15 @@ class TestFSMOrder(FSMCommon):
         self.tag._compute_full_name()
         self.tag1._compute_full_name()
         config = self.env["res.config.settings"].create({})
-        config.module_fieldservice_repair = True
+        config.group_fsm_equipment = False
+        config.auto_populate_equipments_on_order = True
         config._onchange_group_fsm_equipment()
+        self.assertFalse(config.auto_populate_equipments_on_order)
+        config.module_fieldservice_repair = False
         config._onchange_module_fieldservice_repair()
+        config.module_fieldservice_repair = True
+        config._onchange_module_fieldservice_repair()
+        self.assertTrue(config.group_fsm_equipment)
         order3._track_subtype(self.init_values)
         order4._track_subtype(self.init_values)
         order3._track_subtype(self.init_values_2)
@@ -348,4 +354,35 @@ class TestFSMOrder(FSMCommon):
             wizard_form.record.action_sign()
         # Check that the signature has been updated
         self.assertEqual(order.signed_by, "Test Customer")
-        self.assertEqual(order.signed_on, fields.Datetime.now())
+        self.assertEqual(order.signed_on, now)
+
+    def test_equipment_removed_on_company_mismatch(self):
+        """Equipments from another company are dropped on company change."""
+        company2 = self.env["res.company"].create({"name": "FSM Other Company"})
+        equipment = self.env["fsm.equipment"].create(
+            {
+                "name": "Company Mismatch Equipment",
+                "current_location_id": self.test_location.id,
+                "location_id": self.test_location.id,
+                "company_id": self.env.company.id,
+            }
+        )
+        order = self.Order.create(
+            {
+                "location_id": self.test_location.id,
+                "equipment_ids": [Command.set(equipment.ids)],
+            }
+        )
+        self.assertIn(equipment, order.equipment_ids)
+        order.company_id = company2
+        self.assertFalse(order.equipment_ids)
+
+    def test_onchange_template_without_type_or_team(self):
+        template = self.env["fsm.template"].create(
+            {"name": "Bare Template", "duration": 2.5}
+        )
+        order = self.Order.new(
+            {"location_id": self.test_location.id, "template_id": template.id}
+        )
+        order._onchange_template_id()
+        self.assertEqual(order.scheduled_duration, 2.5)

--- a/fieldservice/tests/test_fsm_person.py
+++ b/fieldservice/tests/test_fsm_person.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.fields import Domain
+from odoo.tests import Form
 
 from .test_fsm_common import FSMCommon
 
@@ -29,6 +30,22 @@ class FSMPerson(FSMCommon):
             test_worker_one.partner_id.active,
             "Activating FSM Person must make related partner active",
         )
+
+    def test_create_fsm_worker_from_form(self):
+        """Workers can be saved from the UI without a related partner."""
+        with Form(self.Worker, view="fieldservice.fsm_person_form") as f:
+            f.name = "Worker From Form"
+        worker = f.save()
+        self.assertTrue(worker.partner_id)
+        self.assertTrue(worker.fsm_person)
+        self.assertTrue(worker.partner_id.fsm_person)
+
+    def test_fsm_person_create_multi(self):
+        workers = self.Worker.create([{"name": "Worker A"}, {"name": "Worker B"}])
+        self.assertEqual(len(workers), 2)
+        for worker in workers:
+            self.assertTrue(worker.fsm_person)
+            self.assertTrue(worker.partner_id)
 
     def test_fsm_person_search(self):
         # Setup locations
@@ -66,3 +83,8 @@ class FSMPerson(FSMCommon):
         search_domain = Domain("location_ids", "=", "Location")
         workers = self.Worker.search(search_domain)
         self.assertEqual(len(workers), 3, "Incorrect search number result")
+        # No matching location name: search returns empty without SQL IN clause.
+        workers = self.Worker.search(
+            Domain("location_ids", "=", "No Such Location XYZ")
+        )
+        self.assertFalse(workers)

--- a/fieldservice/tests/test_fsm_wizard.py
+++ b/fieldservice/tests/test_fsm_wizard.py
@@ -100,6 +100,40 @@ class FSMWizard(FSMCommon):
             Domain("name", "=", "Parent Partner")
         )
 
-        # check all children were assigned type 'other'
-        for child in wiz_parent.child_ids:
+        # check all partner children were assigned type 'other'
+        for child in wiz_parent.partner_id.child_ids:
             self.assertEqual(child.type, "other")
+
+    def test_prepare_fsm_location_root_partner(self):
+        vals = self.Wizard._prepare_fsm_location(self.test_partner)
+        self.assertEqual(
+            vals,
+            {
+                "partner_id": self.test_partner.id,
+                "owner_id": self.test_partner.id,
+            },
+        )
+
+    def test_prepare_fsm_location_child_under_fsm_parent(self):
+        self.Wizard.action_convert_location(self.test_partner)
+        parent_location = self.test_partner.fsm_location_ids[:1]
+        child_partner = self.env["res.partner"].create(
+            {
+                "parent_id": self.test_partner.id,
+                "name": "Child Under FSM Parent",
+            }
+        )
+        vals = self.Wizard._prepare_fsm_location(child_partner)
+        self.assertEqual(vals["owner_id"], self.test_partner.id)
+        self.assertEqual(vals["parent_id"], parent_location.id)
+
+    def test_prepare_fsm_location_child_without_parent_location(self):
+        child_partner = self.env["res.partner"].create(
+            {
+                "parent_id": self.parent_partner.id,
+                "name": "Child No FSM Parent",
+            }
+        )
+        vals = self.Wizard._prepare_fsm_location(child_partner)
+        self.assertEqual(vals["owner_id"], self.parent_partner.id)
+        self.assertNotIn("parent_id", vals)

--- a/fieldservice/tests/test_res_partner.py
+++ b/fieldservice/tests/test_res_partner.py
@@ -27,3 +27,36 @@ class FSMResPartner(FSMCommon):
         expected_domain = Domain("id", "in", [self.loc_1.id, self.loc_2.id])
         action = self.parent_partner.action_open_owned_locations()
         self.assertEqual(action["domain"], expected_domain)
+
+    def test_action_open_owned_locations_empty(self):
+        partner = self.env["res.partner"].create({"name": "No Locations"})
+        action = partner.action_open_owned_locations()
+        self.assertEqual(action["res_model"], "fsm.location")
+        self.assertFalse(action.get("res_id"))
+        self.assertFalse(action.get("domain"))
+        # Empty recordset: loop body is skipped.
+        self.assertFalse(self.env["res.partner"].action_open_owned_locations())
+
+    def test_partner_convert_to_location_action(self):
+        self.test_partner.action_fsm_convert_to_location()
+        self.assertTrue(self.test_partner.fsm_location)
+        self.assertTrue(self.test_partner.fsm_location_ids)
+
+    def test_partner_convert_to_person_action(self):
+        partner = self.env["res.partner"].create({"name": "Convert To Worker"})
+        partner.action_fsm_convert_to_person()
+        self.assertTrue(partner.fsm_person)
+        self.assertTrue(
+            self.env["fsm.person"].search(Domain("partner_id", "=", partner.id))
+        )
+
+    def test_partner_write_type_fsm_location(self):
+        partner = self.env["res.partner"].create(
+            {
+                "parent_id": self.parent_partner.id,
+                "name": "Written As Location",
+                "type": "contact",
+            }
+        )
+        partner.write({"type": "fsm_location"})
+        self.assertTrue(partner.fsm_location_ids)

--- a/fieldservice/views/fsm_location.xml
+++ b/fieldservice/views/fsm_location.xml
@@ -103,13 +103,8 @@
                         <group id="main-left">
                             <field name="id" invisible="1" />
                             <field name="parent_id" domain="[('id', '!=', id)]" />
-                            <field
-                                name="partner_id"
-                                groups="base.group_no_one"
-                                required="0"
-                                readonly="1"
-                            />
-                            <field name="owner_id" />
+                            <field name="partner_id" invisible="1" required="0" />
+                            <field name="owner_id" required="0" />
                             <field
                                 name="contact_id"
                                 context="{'default_service_location_id': id, 'default_street': street, 'default_street2': street2, 'default_city': city, 'default_state_id': state_id, 'default_zip': zip, 'default_country_id': country_id}"

--- a/fieldservice/views/fsm_person.xml
+++ b/fieldservice/views/fsm_person.xml
@@ -87,9 +87,7 @@
                             <strong
                             >The contact linked to this user is still active</strong>
                         </div>
-                        <div>You can archive the contact
-                        <field name="partner_id" required="0" readonly="1" />
-                        </div>
+                        <div>You can archive the contact from the partner form.</div>
                     </div>
                     <label for="name" class="oe_edit_only" />
                     <h1>
@@ -98,12 +96,7 @@
                     </h1>
                     <group>
                         <group>
-                            <field
-                                name="partner_id"
-                                groups="base.group_no_one"
-                                required="0"
-                                readonly="1"
-                            />
+                            <field name="partner_id" invisible="1" required="0" />
                             <field
                                 name="category_ids"
                                 widget="many2many_tags"

--- a/fieldservice/views/res_partner.xml
+++ b/fieldservice/views/res_partner.xml
@@ -47,7 +47,24 @@
                                 context="{'default_contact_id': id}"
                             />
                         </group>
-                        <group />
+                        <group>
+                            <button
+                                name="action_fsm_convert_to_location"
+                                type="object"
+                                string="Convert to FS Location"
+                                class="btn-link"
+                                invisible="fsm_location"
+                                groups="fieldservice.group_fsm_dispatcher"
+                            />
+                            <button
+                                name="action_fsm_convert_to_person"
+                                type="object"
+                                string="Convert to FS Worker"
+                                class="btn-link"
+                                invisible="fsm_person"
+                                groups="fieldservice.group_fsm_dispatcher"
+                            />
+                        </group>
                     </group>
                 </page>
             </notebook>

--- a/fieldservice/wizard/fsm_wizard.py
+++ b/fieldservice/wizard/fsm_wizard.py
@@ -31,13 +31,19 @@ class FSMWizard(models.TransientModel):
         return {"type": "ir.actions.act_window_close"}
 
     def _prepare_fsm_location(self, partner):
-        return {"partner_id": partner.id, "owner_id": partner.id}
+        owner = partner.parent_id or partner
+        vals = {"partner_id": partner.id, "owner_id": owner.id}
+        if partner.parent_id:
+            parent_location = partner.parent_id.fsm_location_ids[:1]
+            if parent_location:
+                vals["parent_id"] = parent_location.id
+        return vals
 
     def action_convert_location(self, partner):
         fl_model = self.env["fsm.location"]
         if fl_model.search_count(Domain("partner_id", "=", partner.id)) == 0:
             fl_model.create(self._prepare_fsm_location(partner))
-            partner.write({"fsm_location": True})
+            partner.write({"fsm_location": True, "type": "fsm_location"})
             self.action_other_address(partner)
         else:
             raise UserError(


### PR DESCRIPTION
## Summary
- Restores delegated partner creation when saving service locations/workers (complete port of #1556 / #1557).
- Root locations are self-owned; sub-locations inherit `owner_id` from `parent_id` when omitted.
- Hides delegated `partner_id` (`invisible` + `required="0"`) and relaxes `owner_id` form required so UI saves work.
- Adds convert buttons on the contact Field Service tab; wizard links child partners under an existing parent FSM location.
- Guards partner auto-conversion with `creating_fsm_location` / `creating_fsm_person` context.

Fixes #1218.

## Test plan
- [ ] Install `fieldservice` on Odoo 19 Community
- [ ] Create a root service location from Field Service > Master Data > Locations (no owner/partner)
- [ ] Create a field service worker from Field Service > Master Data > Workers
- [ ] Open a contact, Field Service tab, use "Convert to FS Location" / "Convert to FS Worker"
- [ ] Create a child contact with type Location on a customer and verify FSM location is created under the parent
- [ ] Create a sub-location without owner and verify it inherits the parent owner
- [ ] Run module tests: `fieldservice/tests/`


Made with [Cursor](https://cursor.com)