### PR TITLE
[FIX] fieldservice: Spanish service order report translation

### DIFF
--- a/fieldservice/i18n/es.po
+++ b/fieldservice/i18n/es.po
@@ -44,7 +44,7 @@ msgstr "# de Ubicaciones Propias"
 #. module: fieldservice
 #: model:ir.actions.report,print_report_name:fieldservice.action_report_fsm_order
 msgid "'Service Order - %s' % (object.name)"
-msgstr "Orden de servicio - %s' % (object.name)"
+msgstr "'Orden de servicio - %s' % (object.name)"
 
 #. module: fieldservice
 #: model_terms:ir.ui.view,arch_db:fieldservice.view_team_kanban


### PR DESCRIPTION
## Why
The Spanish translation for the Service Order print filename was malformed. Odoo evaluates `print_report_name` with `safe_eval`, so the broken string produced a `SyntaxError` when printing the report in Spanish, preventing the file from being generated.

## What changed
This fixes the translation entry in `fieldservice/i18n/es.po` so it matches the valid Python expression used by the report definition:

- before: `Orden de servicio - %s' % (object.name)`
- after: `'Orden de servicio - %s' % (object.name)`

This is a translation-only change and keeps the report name generation consistent with the other locales.

## Validation
Reviewed the final diff and confirmed the translation matches the expected Python-safe format used by the report definition.