### PR TITLE
[18.0][FIX] fieldservice_route: one dayroute per worker and day

### DIFF
--- a/fieldservice_route/README.rst
+++ b/fieldservice_route/README.rst
@@ -45,23 +45,24 @@ Configuration
 
 To use this module, you need to:
 
--  Go to Field Service > Configuration > Stages
--  Define the workflow of your routes by creating new stages whose type
-   is "Route"
--  Go to Field Service > Master Data > Routes
--  Create your routes by setting their name and selecting their
-   territory
+- Go to Field Service > Configuration > Stages
+- Define the workflow of your routes by creating new stages whose type
+  is "Route"
+- Go to Field Service > Master Data > Routes
+- Create your routes by setting their name and selecting their territory
+- Set "Maximum Orders" on a route to cap how many orders a day route for
+  it can hold; leave it at its default of 0 for no limit
 
 Usage
 =====
 
 To use this module, you need to:
 
--  Go to Field Service
--  Create or select an order
--  Assign it to a worker and schedule it
--  Go to Field Service > Dashboard > Day Routes. A new record has been
-   created.
+- Go to Field Service
+- Create or select an order
+- Assign it to a worker and schedule it
+- Go to Field Service > Dashboard > Day Routes. A new record has been
+  created.
 
 Bug Tracker
 ===========
@@ -84,20 +85,20 @@ Authors
 Contributors
 ------------
 
--  Maxime Chambreuil <mchambreuil@opensourceintegrators.com>
--  Nikul Chaudhary <nikul.chaudhary.serpentcs@gmail.com>
--  Freni Patel <fpatel@opensourceintegrators.com>
--  `Tecnativa <https://www.tecnativa.com>`__:
+- Maxime Chambreuil <mchambreuil@opensourceintegrators.com>
+- Nikul Chaudhary <nikul.chaudhary.serpentcs@gmail.com>
+- Freni Patel <fpatel@opensourceintegrators.com>
+- `Tecnativa <https://www.tecnativa.com>`__:
 
-   -  Víctor Martínez
+  - Víctor Martínez
 
 Other credits
 -------------
 
 The development of this module has been financially supported by:
 
--  Open Source Integrators <https://opensourceintegrators.com>
--  Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+- Open Source Integrators <https://opensourceintegrators.com>
+- Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 
 Maintainers
 -----------

--- a/fieldservice_route/__manifest__.py
+++ b/fieldservice_route/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Field Service Route",
     "summary": "Organize the routes of each day.",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Field Service",
     "license": "AGPL-3",
     "author": "Open Source Integrators, Odoo Community Association (OCA)",

--- a/fieldservice_route/models/fsm_order.py
+++ b/fieldservice_route/models/fsm_order.py
@@ -57,6 +57,8 @@ class FSMOrder(models.Model):
         return [
             ("person_id", "=", values["person_id"]),
             ("date", "=", values["date"]),
+            "|",
+            ("max_order", "=", 0),
             ("order_remaining", ">", 0),
         ]
 
@@ -74,11 +76,20 @@ class FSMOrder(models.Model):
             if self._can_create_dayroute(values):
                 dayroute = dayroute_obj.create(self.prepare_dayroute_values(values))
                 vals.update({"dayroute_id": dayroute.id})
-        # If this was the last order of the dayroute,
-        # delete the dayroute
-        if self.dayroute_id and not self.dayroute_id.order_ids:
-            self.dayroute_id.unlink()
         return vals
+
+    @api.model
+    def _dayroute_trigger_fields(self):
+        """Fields whose write must re-evaluate the order's dayroute.
+
+        Any other field changing on an already assigned/scheduled order is
+        irrelevant to routing and must not touch ``dayroute_id`` at all
+        (see ``write()``): re-running the search unconditionally on every
+        write was the root cause of the duplicated/orphaned dayroutes seen
+        in production, since a route already at capacity would no longer
+        match its own dayroute and a new one would be created for nothing.
+        """
+        return {"person_id", "scheduled_date_start"}
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -92,16 +103,26 @@ class FSMOrder(models.Model):
         return super().create(vals_list)
 
     def write(self, vals):
+        if not self._dayroute_trigger_fields() & vals.keys():
+            return super().write(vals)
+
+        old_dayroutes = self.dayroute_id
         for rec in self:
-            if vals.get("route_id", False):
-                route = self.env["fsm.route"].browse(vals.get("route_id"))
-                vals.update(
-                    {
-                        "scheduled_date_start": route.date,
-                    }
-                )
-            if (vals.get("person_id", False) or rec.person_id) and (
-                vals.get("scheduled_date_start", False) or rec.scheduled_date_start
+            rec_vals = dict(vals)
+            unassigning = any(
+                field in vals and not vals[field]
+                for field in ("person_id", "scheduled_date_start")
+            )
+            if unassigning:
+                rec_vals["dayroute_id"] = False
+            elif (rec_vals.get("person_id") or rec.person_id) and (
+                rec_vals.get("scheduled_date_start") or rec.scheduled_date_start
             ):
-                vals = rec._manage_fsm_route(vals)
-        return super().write(vals)
+                rec_vals = rec._manage_fsm_route(rec_vals)
+            super(FSMOrder, rec).write(rec_vals)
+        # Now that the orders have actually moved, delete the dayroutes
+        # left empty behind them (doing this before the write above ran,
+        # as the previous implementation did, left orphaned dayroutes
+        # since `order_ids` hadn't been updated yet).
+        old_dayroutes._unlink_removable()
+        return True

--- a/fieldservice_route/models/fsm_route_dayroute.py
+++ b/fieldservice_route/models/fsm_route_dayroute.py
@@ -88,7 +88,7 @@ class FSMRouteDayRoute(models.Model):
             [("stage_type", "=", "route"), ("is_default", "=", True)], limit=1
         )
 
-    @api.depends("route_id", "order_ids")
+    @api.depends("route_id", "order_ids", "max_order")
     def _compute_order_count(self):
         for rec in self:
             rec.order_count = len(rec.order_ids)
@@ -154,10 +154,29 @@ class FSMRouteDayRoute(models.Model):
     @api.constrains("route_id", "max_order", "order_count")
     def check_capacity(self):
         for rec in self:
-            if rec.route_id and rec.order_count > rec.max_order:
+            # max_order = 0 means "no limit" (the field's default): see
+            # _get_dayroute_domain in fsm_order.py, which treats it the
+            # same way when looking for a dayroute with free capacity.
+            if rec.route_id and rec.max_order and rec.order_count > rec.max_order:
                 raise ValidationError(
                     _(
                         "The day route is exceeding the maximum number of "
                         "orders of the route."
                     )
                 )
+
+    def _is_removable(self):
+        """Whether this (now possibly empty) dayroute can be deleted.
+
+        A separate, overridable hook instead of inlining the check where
+        it's used: extensions that hang other content off a dayroute
+        besides ``order_ids`` (e.g. assignments of helper technicians)
+        can override this to keep it alive without having to re-implement
+        the cleanup call sites.
+        """
+        self.ensure_one()
+        return not self.order_ids
+
+    def _unlink_removable(self):
+        """Delete the subset of ``self`` that ``_is_removable()``."""
+        return self.exists().filtered(lambda r: r._is_removable()).unlink()

--- a/fieldservice_route/readme/CONFIGURE.md
+++ b/fieldservice_route/readme/CONFIGURE.md
@@ -5,3 +5,5 @@ To use this module, you need to:
   is "Route"
 - Go to Field Service \> Master Data \> Routes
 - Create your routes by setting their name and selecting their territory
+- Set "Maximum Orders" on a route to cap how many orders a day route for
+  it can hold; leave it at its default of 0 for no limit

--- a/fieldservice_route/static/description/index.html
+++ b/fieldservice_route/static/description/index.html
@@ -398,8 +398,9 @@ automatically created for that worker and day.</p>
 <li>Define the workflow of your routes by creating new stages whose type
 is “Route”</li>
 <li>Go to Field Service &gt; Master Data &gt; Routes</li>
-<li>Create your routes by setting their name and selecting their
-territory</li>
+<li>Create your routes by setting their name and selecting their territory</li>
+<li>Set “Maximum Orders” on a route to cap how many orders a day route for
+it can hold; leave it at its default of 0 for no limit</li>
 </ul>
 </div>
 <div class="section" id="usage">

--- a/fieldservice_route/tests/test_fsm_order.py
+++ b/fieldservice_route/tests/test_fsm_order.py
@@ -3,8 +3,9 @@
 # Copyright 2022 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
+from odoo.exceptions import ValidationError
 from odoo.tests import Form, common
 
 
@@ -14,6 +15,7 @@ class FSMOrderRouteCase(common.TransactionCase):
         self.fsm_stage_obj = self.env["fsm.stage"]
         self.fsm_order_obj = self.env["fsm.order"]
         self.fsm_route_obj = self.env["fsm.route"]
+        self.fsm_dayroute_obj = self.env["fsm.route.dayroute"]
         self.test_person = self.env.ref("fieldservice.test_person")
         self.test_location = self.env.ref("fieldservice.test_location")
         date = datetime.now()
@@ -37,6 +39,23 @@ class FSMOrderRouteCase(common.TransactionCase):
         )
         self.test_location.fsm_route_id = self.fsm_route_id.id
 
+    def _create_order(self, location=None, person=None, date=None):
+        """Create an order the same way the web Form does: with
+        ``person_id``/``fsm_route_id`` already resolved in ``vals``, so
+        ``create()`` manages the dayroute (mirrors what onchange does when
+        creating through the UI, see ``test_create_day_route``)."""
+        location = location or self.test_location
+        person = person or self.test_person
+        date = date or self.date
+        return self.fsm_order_obj.create(
+            {
+                "location_id": location.id,
+                "fsm_route_id": location.fsm_route_id.id,
+                "person_id": person.id,
+                "scheduled_date_start": date,
+            }
+        )
+
     def test_create_day_route(self):
         order_form = Form(self.fsm_order_obj)
         order_form.location_id = self.test_location
@@ -47,3 +66,137 @@ class FSMOrderRouteCase(common.TransactionCase):
         self.assertEqual(order.dayroute_id.person_id, order.person_id)
         self.assertEqual(order.dayroute_id.date, order.scheduled_date_start.date())
         self.assertEqual(order.dayroute_id.route_id, order.fsm_route_id)
+
+    def test_write_unrelated_field_keeps_dayroute(self):
+        """A write() that doesn't touch person/date/route must not
+        re-trigger dayroute management (bug A). With the route already at
+        capacity, re-running the search on every write kicks the order out
+        into a brand new dayroute and orphans the original one — the exact
+        duplicate reported in production, e.g. from the writes
+        ``fieldservice_calendar`` performs right after create()."""
+        self.fsm_route_id.max_order = 1
+        order = self._create_order()
+        dayroute = order.dayroute_id
+        order.write({"description": "<p>irrelevant change</p>"})
+        self.assertEqual(order.dayroute_id, dayroute)
+        self.assertEqual(
+            self.fsm_dayroute_obj.search_count(
+                [
+                    ("person_id", "=", self.test_person.id),
+                    ("date", "=", self.date.date()),
+                ]
+            ),
+            1,
+        )
+
+    def test_two_orders_same_day_share_dayroute(self):
+        """Two orders for the same technician and day must share a single
+        dayroute (the core of P0 #4)."""
+        order1 = self._create_order()
+        order2 = self._create_order()
+        self.assertEqual(order1.dayroute_id, order2.dayroute_id)
+        self.assertEqual(
+            self.fsm_dayroute_obj.search_count(
+                [
+                    ("person_id", "=", self.test_person.id),
+                    ("date", "=", self.date.date()),
+                ]
+            ),
+            1,
+        )
+
+    def test_change_date_moves_and_cleans_dayroute(self):
+        """Moving the only order of a dayroute to another day must create/
+        reuse the dayroute of the new day and delete the now-empty old one
+        (bug B: the cleanup must happen after the order is actually moved)."""
+        order = self._create_order()
+        old_dayroute = order.dayroute_id
+        new_date = self.date + timedelta(days=1)
+        order.write({"scheduled_date_start": new_date})
+        self.assertNotEqual(order.dayroute_id, old_dayroute)
+        self.assertFalse(old_dayroute.exists())
+        self.assertEqual(order.dayroute_id.date, new_date.date())
+
+    def test_change_date_keeps_nonempty_dayroute(self):
+        """Moving one of several orders off a dayroute must not delete it
+        while orders remain."""
+        order1 = self._create_order()
+        order2 = self._create_order()
+        old_dayroute = order1.dayroute_id
+        new_date = self.date + timedelta(days=1)
+        order1.write({"scheduled_date_start": new_date})
+        self.assertTrue(old_dayroute.exists())
+        self.assertEqual(old_dayroute.order_ids, order2)
+
+    def test_multi_record_write_no_cross_contamination(self):
+        """A single write() on a recordset mixing orders of different
+        technicians must resolve the dayroute of each record independently
+        (bug A: the shared/mutated ``vals`` dict made every record end up
+        pointing at the last computed dayroute)."""
+        person2 = self.env["fsm.person"].create({"name": "Test Person 2"})
+        location2 = self.env.ref("fieldservice.location_1")
+        route2 = self.fsm_route_obj.create(
+            {
+                "name": "Demo Route 2",
+                "max_order": 10,
+                "fsm_person_id": person2.id,
+                "day_ids": [(6, 0, self.days)],
+            }
+        )
+        location2.fsm_route_id = route2.id
+
+        order1 = self._create_order()
+        order2 = self._create_order(location=location2, person=person2)
+        new_date = self.date + timedelta(days=1)
+
+        (order1 | order2).write({"scheduled_date_start": new_date})
+
+        self.assertEqual(order1.dayroute_id.person_id, self.test_person)
+        self.assertEqual(order2.dayroute_id.person_id, person2)
+        self.assertEqual(order1.dayroute_id.date, new_date.date())
+        self.assertEqual(order2.dayroute_id.date, new_date.date())
+        self.assertNotEqual(order1.dayroute_id, order2.dayroute_id)
+
+    def test_max_order_respected(self):
+        """With a finite capacity, a full dayroute must not accept more
+        orders: new orders open a new dayroute, and forcing one into the
+        full dayroute must raise (bug C: with a real capacity limit, the
+        domain must still find/refuse dayroutes correctly)."""
+        self.fsm_route_id.max_order = 1
+        order1 = self._create_order()
+        order2 = self._create_order()
+        self.assertNotEqual(order1.dayroute_id, order2.dayroute_id)
+        with self.assertRaises(ValidationError):
+            order2.dayroute_id = order1.dayroute_id.id
+
+    def test_max_order_zero_unlimited(self):
+        """``max_order = 0`` must mean "no limit": several orders for the
+        same technician/day must all land on the same single dayroute
+        without raising (bug C)."""
+        self.fsm_route_id.max_order = 0
+        orders = self.fsm_order_obj
+        for _i in range(3):
+            orders |= self._create_order()
+        dayroutes = orders.mapped("dayroute_id")
+        self.assertEqual(len(dayroutes), 1)
+        self.assertEqual(
+            self.fsm_dayroute_obj.search_count(
+                [
+                    ("person_id", "=", self.test_person.id),
+                    ("date", "=", self.date.date()),
+                ]
+            ),
+            1,
+        )
+
+    def test_unassign_clears_dayroute(self):
+        """Unassigning an order (clearing both technician and scheduled
+        date, as the auto-reschedule cron of the downstream product does)
+        must detach it from its dayroute and delete the dayroute if it was
+        the last order left in it (bug D)."""
+        order = self._create_order()
+        dayroute = order.dayroute_id
+        self.assertTrue(dayroute)
+        order.write({"person_id": False, "scheduled_date_start": False})
+        self.assertFalse(order.dayroute_id)
+        self.assertFalse(dayroute.exists())


### PR DESCRIPTION
## Problem

In production, technicians end up with several `fsm.route.dayroute` records for the same day, some of them empty/orphaned. Three independent defects in `fsm.order`/`fsm.route.dayroute` compound into this:

**1. `write()` re-runs dayroute management on every write, regardless of what changed**

```python
def write(self, vals):
    for rec in self:
        ...
        if (vals.get("person_id", False) or rec.person_id) and (
            vals.get("scheduled_date_start", False) or rec.scheduled_date_start
        ):
            vals = rec._manage_fsm_route(vals)
    return super().write(vals)
```

The condition is true for *any* write on an order that already has a technician and a scheduled date, even if `vals` doesn't touch either. Combined with defect 3 below, an unrelated write on an order whose route is already at capacity kicks it out into a brand new dayroute for no reason — this reproduces exactly the "writes right after create()" pattern from modules like `fieldservice_calendar`.

The same loop also mutates and reassigns the *same* `vals` dict shared across `self`, then calls `super().write(vals)` **once**, outside the loop, with whatever `vals` looks like after the last iteration — so in a multi-record write mixing orders of different technicians, every record ends up written with the *last* record's resolved `dayroute_id`.

There's also a dead branch handling `vals.get("route_id")` / `route.date`: neither `route_id` nor `date` exist on `fsm.order`/`fsm.route` respectively, so this can never execute (or raises `AttributeError` if it ever did).

**2. The empty-dayroute cleanup runs before the order has actually moved**

```python
def _manage_fsm_route(self, vals):
    ...
    if self.dayroute_id and not self.dayroute_id.order_ids:
        self.dayroute_id.unlink()
    return vals
```

This check happens *before* `super().write(vals)` applies the new `dayroute_id`, so `self.dayroute_id.order_ids` still contains the order that is about to leave — the condition is never true when it should be, and the old (now-empty) dayroute is never deleted when an order changes day/technician.

**3. `max_order = 0` (the field's own default) makes the domain unsatisfiable**

```python
def _get_dayroute_domain(self, values):
    return [
        ("person_id", "=", values["person_id"]),
        ("date", "=", values["date"]),
        ("order_remaining", ">", 0),
    ]
```

`order_remaining = max_order - order_count`, and `max_order` defaults to 0 (`fsm.route.max_order`, "Maximum number of orders per day route"). With no explicit capacity configured, `order_remaining` is never positive, so the existing dayroute is never found again and a new one gets created on every write. `check_capacity()` has the same asymmetry the other way: with `max_order = 0`, a *single* order already violates it.

## Fix

- `write()` only touches dayroute management when `vals` actually contains `person_id` or `scheduled_date_start` (new `_dayroute_trigger_fields()` hook); any other field write returns early via `super().write(vals)`, untouched.
- Each record gets its own copy of `vals` and its own `super(FSMOrder, rec).write(rec_vals)` call, so a batch write can no longer cross-contaminate records.
- Unassigning an order (both `person_id` and `scheduled_date_start` cleared — e.g. by an auto-reschedule cron) now clears `dayroute_id` too, instead of leaving it pointing at a dayroute it no longer belongs to.
- The now-emptied dayroutes are deleted *after* the per-record writes have actually happened.
- `_get_dayroute_domain()` and `check_capacity()` both treat `max_order = 0` as "no limit", consistent with the field's default and help text: `'|', ('max_order', '=', 0), ('order_remaining', '>', 0)`.
- The cleanup itself is now a small overridable pair, `_is_removable()` / `_unlink_removable()`, instead of being inlined at the two call sites — so a downstream module that hangs other content off a dayroute (e.g. helper technicians' own time slots, not just `order_ids`) can veto the deletion without having to reimplement or monkeypatch the cleanup.

8 new tests in `fieldservice_route/tests/test_fsm_order.py` reproduce each defect against `HEAD` (6 fail/error without the fix) and pass with it; the existing test suite plus `fieldservice_sale_stock_route`, `fieldservice_route_availability` and `fieldservice_calendar` (all of which touch dayroutes) were run together against the change with no regressions.

## Known limitations (out of scope for this PR)

- `_get_dayroute_values()`'s `.date()` call on `scheduled_date_start` doesn't account for the user's timezone.
- `date_start_planned` is hardcoded to 8:00 (there's already a `# TODO: Use the worker timezone and working schedule` upstream).
- `_default_team_id()` raises if no `fsm.team` exists yet.

## Semantics change to flag for review

Before this fix, `max_order = 0` effectively meant "reject everything after the first write" (an unusable state, given it's the field's own default). After this fix it means "no limit", matching the help text. If reviewers would rather keep an explicit capacity requirement, the domain could instead read `('order_remaining', '>', 0)` gated by `max_order > 0` only — happy to adjust.