### PR TITLE
[FIX] fieldservice_geoengine: Batch creation

### DIFF
--- a/fieldservice_geoengine/models/fsm_location.py
+++ b/fieldservice_geoengine/models/fsm_location.py
@@ -14,10 +14,14 @@ class FSMLocation(models.Model):
     custom_color = fields.Char(related="stage_id.custom_color", string="Stage Color")
 
     @api.model_create_multi
-    def create(self, vals):
-        res = super(FSMLocation, self).create(vals)
-        if not res.partner_latitude or not res.partner_longitude:
-            res.with_context(force_geo_localize=True).geo_localize()
+    def create(self, vals_list):
+        res = super(FSMLocation, self).create(vals_list)
+        not_localized_locations = res.filtered(
+            lambda location: not location.partner_latitude
+            or not location.partner_longitude
+        )
+        if not_localized_locations:
+            not_localized_locations.with_context(force_geo_localize=True).geo_localize()
         return res
 
     def geo_localize(self):

--- a/fieldservice_geoengine/tests/test_fsm_location.py
+++ b/fieldservice_geoengine/tests/test_fsm_location.py
@@ -166,3 +166,16 @@ class TestFsmLocation(TransactionCase):
         self.assertTrue(test_location.shape)
         test_location.partner_longitude = False
         self.assertFalse(test_location.shape)
+
+    def test_multi_create(self):
+        """Locations can be created in batch."""
+        locations = self.FSMLocation.create(
+            [
+                {
+                    "name": f"Test location {loc_index}",
+                    "owner_id": self.location_partner_1.id,
+                }
+                for loc_index in range(2)
+            ]
+        )
+        self.assertTrue(locations)


### PR DESCRIPTION
When attempting to create multiple locations at once, the following is raised:
```
[...]
  File "/opt/odoo/auto/addons/fieldservice_geoengine/tests/test_fsm_location.py", line 172, in test_multi_create
    locations = self.FSMLocation.create(
  File "<decorator-gen-161>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 431, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/auto/addons/fieldservice_geoengine/models/fsm_location.py", line 19, in create
    if not res.partner_latitude or not res.partner_longitude:
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1152, in __get__
    record.ensure_one()
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5222, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: fsm.location(15, 16)
```