### PR TITLE
[FIX] fieldservice: Quick search finds locations with no reference

### DIFF
--- a/fieldservice/models/fsm_location.py
+++ b/fieldservice/models/fsm_location.py
@@ -10,6 +10,12 @@ class FSMLocation(models.Model):
     _inherits = {"res.partner": "partner_id"}
     _inherit = ["mail.thread", "mail.activity.mixin", "fsm.model.mixin"]
     _description = "Field Service Location"
+    # Aligned with searching by `name` in the search view,
+    # is overridden by search_on_complete_name (see `name_search`)
+    _rec_names_search = [
+        "name",
+        "ref",
+    ]
     _stage_type = "location"
 
     direction = fields.Html()
@@ -107,15 +113,18 @@ class FSMLocation(models.Model):
 
     @api.model
     def name_search(self, name, args=None, operator="ilike", limit=100):
-        args = args or []
         recs = self.browse()
-        if name:
-            recs = self.search([("ref", "ilike", name)] + args, limit=limit)
-        if not recs and self.env.company.search_on_complete_name:
+        if self.env.company.search_on_complete_name:
+            args = args or []
             recs = self.search([("complete_name", operator, name)] + args, limit=limit)
-        if not recs and not self.env.company.search_on_complete_name:
-            recs = self.search([("name", operator, name)] + args, limit=limit)
-        return recs.name_get()
+
+        if recs:
+            result = recs.name_get()
+        else:
+            result = super().name_search(
+                name=name, args=args, operator=operator, limit=limit
+            )
+        return result
 
     @api.onchange("fsm_parent_id")
     def _onchange_fsm_parent_id(self):

--- a/fieldservice/tests/test_fsm_location.py
+++ b/fieldservice/tests/test_fsm_location.py
@@ -283,3 +283,24 @@ class FSMLocation(TransactionCase):
                 [("active", "=", False), ("id", "in", children_loc.ids)]
             )
         )
+
+    def test_search_no_ref(self):
+        """
+        Quick search finds locations with no reference too.
+        """
+        # Arrange
+        no_ref_location = self.test_location.copy(
+            default={
+                "name": "Test ref location",
+                "ref": False,
+            }
+        )
+        ref_location = no_ref_location.copy(default={"ref": "Some ref"})
+
+        # Act
+        quick_search_results = self.Location.name_search("ref")
+
+        # Assert
+        found_ids = [result[0] for result in quick_search_results]
+        self.assertIn(no_ref_location.id, found_ids)
+        self.assertIn(ref_location.id, found_ids)


### PR DESCRIPTION
**Steps**:
1. Create two locations:
    - one only has Name "Test ref location" and no Reference
    - one has both Name and Reference equal to "Test ref location"
2. In an order, click on the Plant field: check that both locations are shown <img width="722" height="160" alt="image" src="https://github.com/user-attachments/assets/e641a623-9814-47e3-9b34-b471ce5395ed" />
3. Type `ref` in the field

**Current behavior**:
Only the location that has both Name and Reference is shown: <img width="722" height="160" alt="image" src="https://github.com/user-attachments/assets/f4846cac-1e3b-4998-a972-0c8dbcb75e53" />

**Expected behavior**:
Both locations are still shown.
This is consistent with searching `ref` in the Locations menu: <img width="2560" height="341" alt="image" src="https://github.com/user-attachments/assets/c0c113d2-c371-4468-929a-502e44d42299" />
because the filter is using both `name` and `ref`:
https://github.com/OCA/field-service/blob/868ecdeab46e0e383c424e317c29046925086704/fieldservice/views/fsm_location.xml#L288-L292

