### PR TITLE
[UPD] Remove maintainers smangukiya and wolfhall

### DIFF
--- a/fieldservice_google_map/README.rst
+++ b/fieldservice_google_map/README.rst
@@ -125,16 +125,13 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-.. |maintainer-wolfhall| image:: https://github.com/wolfhall.png?size=40px
-    :target: https://github.com/wolfhall
-    :alt: wolfhall
 .. |maintainer-max3903| image:: https://github.com/max3903.png?size=40px
     :target: https://github.com/max3903
     :alt: max3903
 
-Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
+Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-wolfhall| |maintainer-max3903| 
+|maintainer-max3903| 
 
 This module is part of the `OCA/field-service <https://github.com/OCA/field-service/tree/19.0/fieldservice_google_map>`_ project on GitHub.
 

--- a/fieldservice_google_map/__manifest__.py
+++ b/fieldservice_google_map/__manifest__.py
@@ -27,7 +27,6 @@
     "installable": True,
     "development_status": "Beta",
     "maintainers": [
-        "wolfhall",
         "max3903",
     ],
 }

--- a/fieldservice_google_map/static/description/index.html
+++ b/fieldservice_google_map/static/description/index.html
@@ -473,8 +473,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
-<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/wolfhall"><img alt="wolfhall" src="https://github.com/wolfhall.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/max3903"><img alt="max3903" src="https://github.com/max3903.png?size=40px" /></a></p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/max3903"><img alt="max3903" src="https://github.com/max3903.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/field-service/tree/19.0/fieldservice_google_map">OCA/field-service</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/fieldservice_repair/README.rst
+++ b/fieldservice_repair/README.rst
@@ -132,16 +132,13 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-.. |maintainer-smangukiya| image:: https://github.com/smangukiya.png?size=40px
-    :target: https://github.com/smangukiya
-    :alt: smangukiya
 .. |maintainer-max3903| image:: https://github.com/max3903.png?size=40px
     :target: https://github.com/max3903
     :alt: max3903
 
-Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
+Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-smangukiya| |maintainer-max3903| 
+|maintainer-max3903| 
 
 This module is part of the `OCA/field-service <https://github.com/OCA/field-service/tree/19.0/fieldservice_repair>`_ project on GitHub.
 

--- a/fieldservice_repair/__manifest__.py
+++ b/fieldservice_repair/__manifest__.py
@@ -17,7 +17,6 @@
     "license": "AGPL-3",
     "development_status": "Beta",
     "maintainers": [
-        "smangukiya",
         "max3903",
     ],
     "installable": True,

--- a/fieldservice_repair/static/description/index.html
+++ b/fieldservice_repair/static/description/index.html
@@ -477,8 +477,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
-<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/smangukiya"><img alt="smangukiya" src="https://github.com/smangukiya.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/max3903"><img alt="max3903" src="https://github.com/max3903.png?size=40px" /></a></p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/max3903"><img alt="max3903" src="https://github.com/max3903.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/field-service/tree/19.0/fieldservice_repair">OCA/field-service</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/fieldservice_sale_stock/README.rst
+++ b/fieldservice_sale_stock/README.rst
@@ -112,9 +112,6 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-.. |maintainer-wolfhall| image:: https://github.com/wolfhall.png?size=40px
-    :target: https://github.com/wolfhall
-    :alt: wolfhall
 .. |maintainer-max3903| image:: https://github.com/max3903.png?size=40px
     :target: https://github.com/max3903
     :alt: max3903
@@ -124,7 +121,7 @@ promote its widespread use.
 
 Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-wolfhall| |maintainer-max3903| |maintainer-brian10048| 
+|maintainer-max3903| |maintainer-brian10048| 
 
 This module is part of the `OCA/field-service <https://github.com/OCA/field-service/tree/19.0/fieldservice_sale_stock>`_ project on GitHub.
 

--- a/fieldservice_sale_stock/__manifest__.py
+++ b/fieldservice_sale_stock/__manifest__.py
@@ -16,7 +16,6 @@
     "license": "AGPL-3",
     "development_status": "Beta",
     "maintainers": [
-        "wolfhall",
         "max3903",
         "brian10048",
     ],

--- a/fieldservice_sale_stock/static/description/index.html
+++ b/fieldservice_sale_stock/static/description/index.html
@@ -461,7 +461,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
 <p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/wolfhall"><img alt="wolfhall" src="https://github.com/wolfhall.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/max3903"><img alt="max3903" src="https://github.com/max3903.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/brian10048"><img alt="brian10048" src="https://github.com/brian10048.png?size=40px" /></a></p>
+<p><a class="reference external image-reference" href="https://github.com/max3903"><img alt="max3903" src="https://github.com/max3903.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/brian10048"><img alt="brian10048" src="https://github.com/brian10048.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/field-service/tree/19.0/fieldservice_sale_stock">OCA/field-service</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>


### PR DESCRIPTION
## Summary
- Remove `smangukiya` from `fieldservice_repair` maintainers
- Remove `wolfhall` from `fieldservice_google_map` and `fieldservice_sale_stock` maintainers

## Test plan
- [ ] Confirm each module still lists at least one active maintainer
- [ ] Confirm `smangukiya` / `wolfhall` no longer appear in any `__manifest__.py` `maintainers`

Made with [Cursor](https://cursor.com)