### PR TITLE
[FIX] fieldservice: Quick search finds locations with no reference

### DIFF
--- a/fieldservice/models/fsm_location.py
+++ b/fieldservice/models/fsm_location.py
@@ -10,8 +10,15 @@ class FSMLocation(models.Model):
     _inherits = {"res.partner": "partner_id"}
     _inherit = ["mail.thread", "mail.activity.mixin", "fsm.model.mixin"]
     _description = "Field Service Location"
+    # Is overridden by search_on_complete_name (see `name_search`)
+    _rec_names_search = [
+        "email",
+        "name",
+        "partner_id.vat",
+        "ref",
+    ]
     _stage_type = "location"
-    _rec_names_search = ["complete_name"]
+    _rec_name = "complete_name"
 
     direction = fields.Html()
     partner_id = fields.Many2one(
@@ -75,22 +82,19 @@ class FSMLocation(models.Model):
     )
 
     @api.model
-    def name_search(self, name="", args=None, operator="ilike", limit=100):
-        args = args or []
-        if name:
-            locations = self.search(
-                [
-                    "|",
-                    "|",
-                    ("name", operator, name),
-                    ("partner_id.vat", operator, name),
-                    ("email", operator, name),
-                ]
-                + args,
-                limit=limit,
+    def name_search(self, name, args=None, operator="ilike", limit=100):
+        recs = self.browse()
+        if self.env.company.search_on_complete_name:
+            args = args or []
+            recs = self.search([("complete_name", operator, name)] + args, limit=limit)
+
+        if recs:
+            result = recs.name_get()
+        else:
+            result = super().name_search(
+                name=name, args=args, operator=operator, limit=limit
             )
-            return locations.name_get()
-        return super().name_search(name, args, operator, limit)
+        return result
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/fieldservice/tests/test_fsm_location.py
+++ b/fieldservice/tests/test_fsm_location.py
@@ -2,7 +2,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import ValidationError
-from odoo.tests.common import Form, TransactionCase
+from odoo.tests import Form
+from odoo.tests.common import TransactionCase
 
 
 class FSMLocation(TransactionCase):
@@ -344,3 +345,24 @@ class FSMLocation(TransactionCase):
         )
         self.assertEqual(location.partner_id, partner)
         self.assertFalse(location.partner_id.parent_id)
+
+    def test_search_no_ref(self):
+        """
+        Quick search finds locations with no reference too.
+        """
+        # Arrange
+        no_ref_location = self.test_location.copy(
+            default={
+                "name": "Test ref location",
+                "ref": False,
+            }
+        )
+        ref_location = no_ref_location.copy(default={"ref": "Some ref"})
+
+        # Act
+        quick_search_results = self.Location.name_search("ref")
+
+        # Assert
+        found_ids = [result[0] for result in quick_search_results]
+        self.assertIn(no_ref_location.id, found_ids)
+        self.assertIn(ref_location.id, found_ids)


### PR DESCRIPTION
Forward port of https://github.com/OCA/field-service/pull/1613.

Here there was no issue because the model is always searching on `complete_name`, but `search_on_complete_name` was ignored, so I aligned the code to the linked PR.