### PR TITLE
[FIX] fieldservice: fix location parent_path under non-C collations

### DIFF
--- a/fieldservice/__manifest__.py
+++ b/fieldservice/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Field Service",
     "summary": "Manage Field Service Locations, Workers and Orders",
-    "version": "19.0.1.2.1",
+    "version": "19.0.1.2.2",
     "license": "AGPL-3",
     "category": "Field Service",
     "author": "Gray Matter Logic, Odoo Community Association (OCA)",

--- a/fieldservice/models/fsm_location.py
+++ b/fieldservice/models/fsm_location.py
@@ -3,7 +3,9 @@
 
 from odoo import api, fields, models
 from odoo.api import Self
+from odoo.exceptions import UserError
 from odoo.fields import Domain
+from odoo.tools import SQL
 
 
 class FSMLocation(models.Model):
@@ -154,6 +156,48 @@ class FSMLocation(models.Model):
         self.country_id = self.parent_id.country_id
         self.tz = self.parent_id.tz
         self.territory_id = self.parent_id.territory_id
+
+    def _parent_store_update(self):
+        """Update parent_path using LIKE, not ASCII range bounds.
+
+        Odoo core matches descendants with
+        ``parent_path < left(parent_path, -1) || '0'``, which assumes
+        ``'/' < '0'``. That is false under common DB collations such as
+        ``en_US.utf8``, so descendant paths are left stale and
+        ``child_of`` / sublocation counts break.
+        """
+        for parent, records in self.grouped(self._parent_name).items():
+            prefix = parent.parent_path or ""
+            if prefix:
+                parent_ids = {int(label) for label in prefix.split("/")[:-1]}
+                if not parent_ids.isdisjoint(records._ids):
+                    raise UserError(self.env._("Recursion Detected."))
+            updated = dict(
+                self.env.execute_query(
+                    SQL(
+                        """ UPDATE %(table)s child
+                            SET parent_path = concat(%(prefix)s, substr(
+                                child.parent_path,
+                                length(node.parent_path)
+                                - length(node.id || '/') + 1))
+                            FROM %(table)s node
+                            WHERE node.id IN %(ids)s
+                            AND (
+                                child.id = node.id
+                                OR child.parent_path LIKE
+                                    concat(node.parent_path, chr(37))
+                            )
+                            RETURNING child.id, child.parent_path """,
+                        table=SQL.identifier(self._table),
+                        prefix=prefix,
+                        ids=tuple(records.ids),
+                    )
+                )
+            )
+            field = self._fields["parent_path"]
+            for id_, path in updated.items():
+                field._update_cache(self.browse(id_), path)
+            self.browse(updated).modified(["parent_path"])
 
     @api.onchange("territory_id")
     def _onchange_territory_id(self):

--- a/fieldservice/tests/test_fsm_location.py
+++ b/fieldservice/tests/test_fsm_location.py
@@ -111,6 +111,12 @@ class FSMLocation(FSMCommon):
         self.location_3.parent_id = self.location_2
         self.location_2.parent_id = self.location_1
         self.location_1.parent_id = self.test_location
+        # parent_path must include full ancestor chain (collation-safe store)
+        self.assertEqual(
+            self.location_3.parent_path,
+            f"{self.test_location.id}/{self.location_1.id}/"
+            f"{self.location_2.id}/{self.location_3.id}/",
+        )
         # Test sublocation_count of each level
         self.assertEqual(
             (


### PR DESCRIPTION
## Summary
- Odoo core `_parent_store_update` matches descendants with `parent_path < left(path,-1)||'0'`, which assumes `'/' < '0'`.
- That comparison is **false** under `en_US.utf8`, so reparenting a location leaves child `parent_path` values stale.
- Result: `child_of` / `sublocation_count` break (`test_fsm_multi_sublocation` expects `(3,2,1,0)` but gets `(1,0,0,0)`).
- Override `_parent_store_update` on `fsm.location` to use collation-safe `LIKE` matching.

This unblocked the ocabot merge of #1611 (failure was in `fieldservice`, not the migrated module).

## Test scenario
1. Install `fieldservice` on Odoo 19.0 (DB collation `en_US.utf8`).
2. Create locations A, B, C, D; set `D.parent_id=C`, `C.parent_id=B`, `B.parent_id=A`.
3. Confirm `D.parent_path == f"{A.id}/{B.id}/{C.id}/{D.id}/"`.
4. Confirm `A.sublocation_count == 3`.
5. Run: `odoo … --test-tags=/fieldservice:FSMLocation.test_fsm_multi_sublocation`

## Checklist
- [x] Tests pass (39/39 fieldservice)
- [x] pre-commit passes
- [x] Coverage on `fieldservice/models/fsm_location.py` 100% (module TOTAL ~99.58%)


Made with [Cursor](https://cursor.com)